### PR TITLE
Add 'end' key support, for parity with 'home' key

### DIFF
--- a/flowblade-trunk/Flowblade/keyevents.py
+++ b/flowblade-trunk/Flowblade/keyevents.py
@@ -350,6 +350,14 @@ def _handle_tline_key_event(event):
             PLAYER().seek_frame(0)
             _move_to_beginning()
             return True
+
+        # END
+        if event.keyval == Gdk.KEY_End:
+            if PLAYER().is_playing():
+                monitorevent.stop_pressed()
+            PLAYER().seek_end()
+            _move_to_end()
+            return True
     else:
         # HOME
         if event.keyval == Gdk.KEY_Home:
@@ -359,6 +367,16 @@ def _handle_tline_key_event(event):
             gui.editor_window.set_mode_selector_to_mode()
             PLAYER().seek_frame(0)
             _move_to_beginning()
+            return True
+
+        # END
+        if event.keyval == Gdk.KEY_End:
+            if PLAYER().is_playing():
+                monitorevent.stop_pressed()
+            gui.editor_window.handle_insert_move_mode_button_press()
+            gui.editor_window.set_mode_selector_to_mode()
+            PLAYER().seek_end()
+            _move_to_end()
             return True
 
     return False
@@ -611,5 +629,7 @@ def _move_to_beginning():
     updater.repaint_tline()
     updater.update_tline_scrollbar()
     
-    
-    
+def _move_to_end():
+    updater.repaint_tline()
+    updater.update_tline_scrollbar()
+

--- a/flowblade-trunk/Flowblade/mltplayer.py
+++ b/flowblade-trunk/Flowblade/mltplayer.py
@@ -204,6 +204,11 @@ class Player:
         if update_gui:
             updater.update_frame_displayers(frame)
 
+    def seek_end(self, update_gui=True):
+        length = self.get_active_length()
+        last_frame = length - 1
+        self.seek_frame(last_frame, update_gui)
+
     def seek_and_get_rgb_frame(self, frame, update_gui=True):
         # Force range
         length = self.get_active_length()


### PR DESCRIPTION
The 'home' key seeks to the first frame in timeline navigation, but the
'end' key was previously unsupported. This commit gives the 'end' key
feature parity so that a user can press both the 'home' and 'end' keys
to navigate to the beginning and end of the timeline.

By the way, thanks for creating Flowblade, it's excellent!