### PR TITLE
Update bin file count after deleting files

### DIFF
--- a/flowblade-trunk/Flowblade/projectaction.py
+++ b/flowblade-trunk/Flowblade/projectaction.py
@@ -964,6 +964,7 @@ def delete_media_files(force_delete=False):
     bin_indexes.reverse()
     for i in bin_indexes:
         current_bin().file_ids.pop(i)
+    update_current_bin_files_count()
         
     # Delete from project
     for file_id in file_ids:


### PR DESCRIPTION
This one-line update simply updates the bin file count after files are deleted.

Previously, the bin file count GUI element would not get updated after a delete, so the numbers there wouldn't change until something else triggered a visual update.