### PR TITLE
Add option to hide file extensions during import

### DIFF
--- a/flowblade-trunk/Flowblade/editorpersistance.py
+++ b/flowblade-trunk/Flowblade/editorpersistance.py
@@ -176,7 +176,8 @@ def update_prefs_from_widgets(widgets_tuples_tuple):
     
     # Jul-2016 - SvdB - Added play_pause_button
     auto_play_in_clip_monitor_check, auto_center_check, grfx_insert_length_spin, \
-    trim_exit_click, trim_quick_enter, remember_clip_frame, overwrite_clip_drop, cover_delete, play_pause_button, mouse_scroll_action = edit_prefs_widgets
+        trim_exit_click, trim_quick_enter, remember_clip_frame, overwrite_clip_drop, cover_delete, \
+        play_pause_button, mouse_scroll_action, hide_file_ext_button = edit_prefs_widgets
     
     use_english, disp_splash, buttons_style, dark_theme, theme_combo, audio_levels_combo, window_mode_combo = view_prefs_widgets
 
@@ -197,6 +198,7 @@ def update_prefs_from_widgets(widgets_tuples_tuple):
     prefs.trans_cover_delete = cover_delete.get_active()
     # Jul-2016 - SvdB - For play/pause button
     prefs.play_pause = play_pause_button.get_active()
+    prefs.hide_file_ext = hide_file_ext_button.get_active()
     prefs.mouse_scroll_action_is_zoom = (mouse_scroll_action.get_active() == 0)
     
     prefs.use_english_always = use_english.get_active()

--- a/flowblade-trunk/Flowblade/preferenceswindow.py
+++ b/flowblade-trunk/Flowblade/preferenceswindow.py
@@ -29,7 +29,7 @@ import guiutils
 import mltprofiles
 
 PREFERENCES_WIDTH = 730
-PREFERENCES_HEIGHT = 380
+PREFERENCES_HEIGHT = 440
 PREFERENCES_LEFT = 410
 
 select_thumbnail_dir_callback = None # app.py sets at start up
@@ -194,7 +194,11 @@ def _edit_prefs_panel():
     mouse_scroll_action.append_text(_("Zoom, Control to Scroll Horizontal"))
     mouse_scroll_action.append_text(_("Scroll Horizontal, Control to Zoom"))
     mouse_scroll_action.set_active(active)
-    
+
+    hide_file_ext_button = Gtk.CheckButton()
+    if hasattr(prefs, 'hide_file_ext'):
+        hide_file_ext_button.set_active(prefs.hide_file_ext)
+
     # Layout
     row1 = _row(guiutils.get_checkbox_row_box(auto_play_in_clip_monitor, Gtk.Label(label=_("Autoplay new Clips in Clip Monitor"))))
     row2 = _row(guiutils.get_checkbox_row_box(auto_center_on_stop, Gtk.Label(label=_("Center Current Frame on Playback Stop"))))
@@ -207,6 +211,7 @@ def _edit_prefs_panel():
     # Jul-2016 - SvdB - For play_pause button
     row10 = _row(guiutils.get_checkbox_row_box(play_pause_button, Gtk.Label(label=_("Enable single Play/Pause button"))))
     row11 = _row(guiutils.get_two_column_box(Gtk.Label(label=_("Mouse Middle Button Scroll Action")), mouse_scroll_action, PREFERENCES_LEFT))
+    row12 = _row(guiutils.get_checkbox_row_box(hide_file_ext_button, Gtk.Label(label=_("Hide file extensions when importing Clips"))))
     
     vbox = Gtk.VBox(False, 2)
     vbox.pack_start(row5, False, False, 0)
@@ -220,13 +225,15 @@ def _edit_prefs_panel():
     # Jul-2016 - SvdB - For play_pause button
     vbox.pack_start(row10, False, False, 0)
     vbox.pack_start(row11, False, False, 0)
+    vbox.pack_start(row12, False, False, 0)
     vbox.pack_start(Gtk.Label(), True, True, 0)
 
     guiutils.set_margins(vbox, 12, 0, 12, 12)
 
     # Jul-2016 - SvdB - Added play_pause_button
     return vbox, (auto_play_in_clip_monitor, auto_center_on_stop, gfx_length_spin,
-                   trim_exit_on_empty, quick_enter_trim, remember_clip_frame, overwrite_clip_drop, cover_delete, play_pause_button, mouse_scroll_action)
+                  trim_exit_on_empty, quick_enter_trim, remember_clip_frame, overwrite_clip_drop, cover_delete,
+                  play_pause_button, mouse_scroll_action, hide_file_ext_button)
 
 def _view_prefs_panel():
     prefs = editorpersistance.prefs

--- a/flowblade-trunk/Flowblade/projectdata.py
+++ b/flowblade-trunk/Flowblade/projectdata.py
@@ -127,9 +127,14 @@ class Project:
         else: # For non-audio we need write a thumbbnail file and get file lengh while we're at it
              (icon_path, length, info) = thumbnailer.write_image(file_path)
 
+        # Hide file extension if enabled in user preferences
+        clip_name = file_name
+        if editorpersistance.prefs.hide_file_ext == True:
+            clip_name = name
+
         # Create media file object
         media_object = MediaFile(self.next_media_file_id, file_path, 
-                               file_name, media_type, length, icon_path, info)
+                                 clip_name, media_type, length, icon_path, info)
 
         self._add_media_object(media_object)
         


### PR DESCRIPTION
When you add media clips to your project, the default setting is for the
clips to receive the name of the file as the clip name. For example, if
you add 'Scenes/011/11A-3.MOV' into your project, the name of the clip
will be '11A-3.MOV'.

This commit adds an optional user preference to omit the file extension
on the clip name when adding files into your project. For example, the
previously mentioned clip would now receive the name '11A-3' during
import instead.

This preference is controlled by a checkbox under:
    Edit -> Preferences -> Editing ->
        [ ] Hide file extensions when importing Clips

For backwards compatibility, this option is disabled by default, so
existing users should not notice any change in behavior.

---

This feature is useful for me, but comments, suggestions, and constructive criticism are most welcome!
In particular, I wasn't 100% sure if the Editing tab in Preferences was the right place to stick that checkbox. Please feel free to change things around if any of my assumptions are unwarranted.

Thanks!