### PR TITLE
Round FPS to whole numbers for NTSC time code

### DIFF
--- a/flowblade-trunk/Flowblade/utils.py
+++ b/flowblade-trunk/Flowblade/utils.py
@@ -117,6 +117,10 @@ def get_tc_string(frame):
     return get_tc_string_with_fps(frame, fps())
 
 def get_tc_string_with_fps(frame, frames_per_sec):
+    # convert fractional frame rates (like 23.976) into integers,
+    # otherwise the timeline will slowly drift over time
+    frames_per_sec = int(round(frames_per_sec))
+
     fr = frame % frames_per_sec
     sec = frame / frames_per_sec
     mins = sec / 60


### PR DESCRIPTION
This update fixes time code calculations for NTSC frame rates like 23.976 and 29.97.

Before this update, a 60 second (24 * 60 frame) clip in 23.976 frame rate would display a length of "00:01:00:01" in the media clip view list. And a timeline made up of 60 instances of this same clip would
end on "01:00:03:13" as the last frame.

After this update, the same clip shows a length of "00:01:00:00" in the media clip view list, and a timeline made up of 60 instances of this same clip ends on "00:59:59:23".

---

By the way, I double checked that this new behavior is in line with other popular commercial editing programs. I really wish NTSC would have just switched over to a pure 24 FPS during the HD transition...