### PR TITLE
Performance patch (real_time parameter)

### DIFF
--- a/editorpersistance.py
+++ b/editorpersistance.py
@@ -1,0 +1,299 @@
+"""
+    Flowblade Movie Editor is a nonlinear video editor.
+    Copyright 2012 Janne Liljeblad.
+
+    This file is part of Flowblade Movie Editor <http://code.google.com/p/flowblade>.
+
+    Flowblade Movie Editor is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Flowblade Movie Editor is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Flowblade Movie Editor.  If not, see <http://www.gnu.org/licenses/>.
+"""
+
+"""
+Module handles saving and loading data that is related to the editor and not any particular project.
+"""
+
+
+from gi.repository import Gtk
+
+import os
+import pickle
+
+import appconsts
+import mltprofiles
+import utils
+
+PREFS_DOC = "prefs"
+RECENT_DOC = "recent"
+
+MAX_RECENT_PROJS = 15
+UNDO_STACK_DEFAULT = 30
+UNDO_STACK_MIN = 10
+UNDO_STACK_MAX = 100
+
+GLASS_STYLE = 0
+SIMPLE_STYLE = 1
+
+prefs = None
+recent_projects = None
+
+
+def load():
+    """
+    If docs fail to load, new ones are created and saved.
+    """
+    prefs_file_path = utils.get_hidden_user_dir_path() + PREFS_DOC
+    recents_file_path = utils.get_hidden_user_dir_path() + RECENT_DOC
+
+    global prefs, recent_projects
+    try:
+        f = open(prefs_file_path)
+        prefs = pickle.load(f)
+    except:
+        prefs = EditorPreferences()
+        write_file = file(prefs_file_path, "wb")
+        pickle.dump(prefs, write_file)
+
+    try:
+        f = open(recents_file_path)
+        recent_projects = pickle.load(f)
+    except:
+        recent_projects = utils.EmptyClass()
+        recent_projects.projects = []
+        write_file = file(recents_file_path, "wb")
+        pickle.dump(recent_projects, write_file)
+
+    # Remove non-existing projects from recents list
+    remove_list = []
+    for proj_path in recent_projects.projects:
+        if os.path.isfile(proj_path) == False:
+            remove_list.append(proj_path)
+
+    if len(remove_list) > 0:
+        for proj_path in remove_list:
+            recent_projects.projects.remove(proj_path)
+        write_file = file(recents_file_path, "wb")
+        pickle.dump(recent_projects, write_file)
+        
+    # Versions of program may have different prefs objects and 
+    # we may need to to update prefs on disk if user has e.g.
+    # installed later version of Flowblade
+    current_prefs = EditorPreferences()
+    if len(prefs.__dict__) != len(current_prefs.__dict__):
+        current_prefs.__dict__.update(prefs.__dict__)
+        prefs = current_prefs
+        write_file = file(prefs_file_path, "wb")
+        pickle.dump(prefs, write_file)
+        print "prefs updated to new version, new param count:", len(prefs.__dict__)
+
+def save():
+    """
+    Write out prefs and recent_projects files 
+    """
+    prefs_file_path = utils.get_hidden_user_dir_path() + PREFS_DOC
+    recents_file_path = utils.get_hidden_user_dir_path() + RECENT_DOC
+    
+    write_file = file(prefs_file_path, "wb")
+    pickle.dump(prefs, write_file)
+
+    write_file = file(recents_file_path, "wb")
+    pickle.dump(recent_projects, write_file)
+
+def add_recent_project_path(path):
+    """
+    Called when project is saved.
+    """
+    if len(recent_projects.projects) == MAX_RECENT_PROJS:
+        recent_projects.projects.pop(-1)
+        
+    # Reject autosaves.
+    autosave_dir = utils.get_hidden_user_dir_path() + appconsts.AUTOSAVE_DIR
+    file_save_dir = os.path.dirname(path) + "/"        
+    if file_save_dir == autosave_dir:
+        return
+
+    try:
+        index = recent_projects.projects.index(path)
+        recent_projects.projects.pop(index)
+    except:
+        pass
+    
+    recent_projects.projects.insert(0, path)    
+    save()
+    
+def fill_recents_menu_widget(menu_item, callback):
+    """
+    Fills menu item with menuitems to open recent projects.
+    """
+    menu = menu_item.get_submenu()
+
+    # Remove current items
+    items = menu.get_children()
+    for item in items:
+        menu.remove(item)
+    
+    # Add new menu items
+    recent_proj_names = get_recent_projects()
+    if len(recent_proj_names) != 0:
+        for i in range (0, len(recent_proj_names)):
+            proj_name = recent_proj_names[i]
+            proj_name = proj_name.replace("_","__") # to display names with underscored correctly
+            new_item = Gtk.MenuItem(proj_name)
+            new_item.connect("activate", callback, i)
+            menu.append(new_item)
+            new_item.show()
+    # ...or a single non-sensitive Empty item 
+    else:
+        new_item = Gtk.MenuItem(_("Empty"))
+        new_item.set_sensitive(False)
+        menu.append(new_item)
+        new_item.show()
+
+def get_recent_projects():
+    """
+    Returns list of names of recent projects.
+    """
+    proj_list = []
+    for proj_path in recent_projects.projects:
+        proj_list.append(os.path.basename(proj_path))
+    
+    return proj_list
+
+def update_prefs_from_widgets(widgets_tuples_tuple):
+    # Unpack widgets
+    gen_opts_widgets, edit_prefs_widgets, view_prefs_widgets, performance_widgets = widgets_tuples_tuple
+
+    default_profile_combo, open_in_last_opened_check, open_in_last_rendered_check, undo_max_spin, load_order_combo = gen_opts_widgets
+    
+    # Jul-2016 - SvdB - Added play_pause_button
+    auto_play_in_clip_monitor_check, auto_center_check, grfx_insert_length_spin, \
+        trim_exit_click, trim_quick_enter, remember_clip_frame, overwrite_clip_drop, cover_delete, \
+        play_pause_button, mouse_scroll_action, hide_file_ext_button = edit_prefs_widgets
+    
+    use_english, disp_splash, buttons_style, dark_theme, theme_combo, audio_levels_combo, window_mode_combo = view_prefs_widgets
+
+    # Jan-2017 - SvdB
+    perf_render_threads, perf_drop_frames = performance_widgets
+
+    global prefs
+    prefs.open_in_last_opended_media_dir = open_in_last_opened_check.get_active()
+    prefs.remember_last_render_dir = open_in_last_rendered_check.get_active()
+    prefs.default_profile_name = mltprofiles.get_profile_name_for_index(default_profile_combo.get_active())
+    prefs.undos_max = undo_max_spin.get_adjustment().get_value()
+    prefs.media_load_order = load_order_combo.get_active()
+
+    prefs.auto_play_in_clip_monitor = auto_play_in_clip_monitor_check.get_active()
+    prefs.auto_center_on_play_stop = auto_center_check.get_active()
+    prefs.default_grfx_length = int(grfx_insert_length_spin.get_adjustment().get_value())
+    prefs.empty_click_exits_trims = trim_exit_click.get_active()
+    prefs.quick_enter_trims = trim_quick_enter.get_active()
+    prefs.remember_monitor_clip_frame = remember_clip_frame.get_active()
+    prefs.overwrite_clip_drop = (overwrite_clip_drop.get_active() == 0)
+    prefs.trans_cover_delete = cover_delete.get_active()
+    # Jul-2016 - SvdB - For play/pause button
+    prefs.play_pause = play_pause_button.get_active()
+    prefs.hide_file_ext = hide_file_ext_button.get_active()
+    prefs.mouse_scroll_action_is_zoom = (mouse_scroll_action.get_active() == 0)
+    
+    prefs.use_english_always = use_english.get_active()
+    prefs.display_splash_screen = disp_splash.get_active()
+    prefs.buttons_style = buttons_style.get_active() # styles enum values and widget indexes correspond
+    prefs.dark_theme = (dark_theme.get_active() == 1)
+    prefs.theme_fallback_colors = theme_combo.get_active() 
+    prefs.display_all_audio_levels = (audio_levels_combo.get_active() == 0)
+    prefs.global_layout = window_mode_combo.get_active() + 1 # +1 'cause values are 1 and 2
+    # Jan-2017 - SvdB
+    prefs.perf_render_threads = int(perf_render_threads.get_adjustment().get_value())
+    prefs.perf_drop_frames = perf_drop_frames.get_active()
+
+def get_graphics_default_in_out_length():
+    in_fr = int(15000/2) - int(prefs.default_grfx_length/2)
+    out_fr = in_fr + int(prefs.default_grfx_length) - 1 # -1, out inclusive
+    return (in_fr, out_fr, prefs.default_grfx_length)
+
+def create_thumbs_folder_if_needed(user_dir):
+    if prefs.thumbnail_folder == None:
+        thumbs_folder = user_dir + appconsts.THUMBNAILS_DIR
+        if not os.path.exists(thumbs_folder + "/"):
+            os.mkdir(thumbs_folder + "/")
+        prefs.thumbnail_folder = thumbs_folder
+
+def create_rendered_clips_folder_if_needed(user_dir):
+    if prefs.render_folder == None:
+        render_folder = user_dir + appconsts.RENDERED_CLIPS_DIR
+        if not os.path.exists(render_folder + "/"):
+            os.mkdir(render_folder + "/")
+        prefs.render_folder = render_folder
+
+
+class EditorPreferences:
+    """
+    Class holds data of persistant user preferences for editor.
+    """
+
+    def __init__(self):
+        
+        # Every preference needs to have its default value set in this constructor
+        
+        self.open_in_last_opended_media_dir = True
+        self.last_opened_media_dir = None
+        self.img_length = 2000
+        self.auto_save_delay_value_index = 1 # value is index of AUTO_SAVE_OPTS in preferenceswindow._general_options_panel()
+        self.undos_max = UNDO_STACK_DEFAULT
+        self.default_profile_name = 10 # index of default profile
+        self.auto_play_in_clip_monitor = False
+        self.auto_center_on_play_stop = False
+        self.thumbnail_folder = None
+        self.hidden_profile_names = []
+        self.display_splash_screen = True
+        self.auto_move_after_edit = False
+        self.default_grfx_length = 250 # value is in frames
+        self.track_configuration = 0 # this is index on list appconsts.TRACK_CONFIGURATIONS
+        self.AUTO_SAVE_OPTS = None # not used, these are cerated and translated else where
+        self.tabs_on_top = False
+        self.midbar_tc_left = True
+        self.default_layout = True
+        self.exit_allocation = (0, 0)
+        self.media_columns = 2
+        self.app_v_paned_position = 500 # Paned get/set position value
+        self.top_paned_position = 600 # Paned get/set position value
+        self.mm_paned_position = 260 # Paned get/set position value
+        self.render_folder = None
+        self.show_sequence_profile = True
+        self.buttons_style = GLASS_STYLE
+        self.dark_theme = False
+        self.remember_last_render_dir = True
+        self.empty_click_exits_trims = True
+        self.quick_enter_trims = True
+        self.show_vu_meter = True
+        self.remember_monitor_clip_frame = True
+        self.jack_start_up_op = appconsts.JACK_ON_START_UP_NO # not used
+        self.jack_frequency = 48000 # not used 
+        self.jack_output_type = appconsts.JACK_OUT_AUDIO # not used
+        self.media_load_order = appconsts.LOAD_ABSOLUTE_FIRST
+        self.use_english_always = False
+        self.theme_fallback_colors = 0 # index of gui._THEME_COLORS
+        self.display_all_audio_levels = True
+        self.overwrite_clip_drop = True
+        self.trans_cover_delete = True
+        # Jul-2016 - SvdB - For play/pause button
+        self.play_pause = False
+        self.midbar_layout = appconsts.MIDBAR_TC_LEFT
+        self.global_layout = appconsts.SINGLE_WINDOW
+        self.trim_view_default = appconsts.TRIM_VIEW_OFF
+        self.trim_view_message_shown = False
+        self.exit_allocation_window_2 = (0, 0, 0, 0)
+        self.mouse_scroll_action_is_zoom = True
+        self.hide_file_ext = False
+        # Jan-2017 - SvdB
+        # self.perf_render_threads = 1
+        # self.perf_drop_frames = False

--- a/preferenceswindow.py
+++ b/preferenceswindow.py
@@ -1,0 +1,350 @@
+"""
+    Flowblade Movie Editor is a nonlinear video editor.
+    Copyright 2013 Janne Liljeblad.
+
+    This file is part of Flowblade Movie Editor <http://code.google.com/p/flowblade>.
+
+    Flowblade Movie Editor is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Flowblade Movie Editor is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Flowblade Movie Editor.  If not, see <http://www.gnu.org/licenses/>.
+"""
+
+from gi.repository import Gtk
+
+import appconsts
+import dialogs
+import dialogutils
+import editorpersistance
+import gui
+import guiutils
+import mltprofiles
+# Jan-2017 - SvdB - To get the number of CPU cores
+import multiprocessing
+
+PREFERENCES_WIDTH = 730
+PREFERENCES_HEIGHT = 440
+PREFERENCES_LEFT = 410
+
+select_thumbnail_dir_callback = None # app.py sets at start up
+select_render_clips_dir_callback = None # app.py sets at start up
+
+def preferences_dialog():
+
+
+    dialog = Gtk.Dialog(_("Editor Preferences"), None,
+                    Gtk.DialogFlags.MODAL | Gtk.DialogFlags.DESTROY_WITH_PARENT,
+                    (_("Cancel").encode('utf-8'), Gtk.ResponseType.REJECT,
+                    _("OK").encode('utf-8'), Gtk.ResponseType.ACCEPT))
+
+    gen_opts_panel, gen_opts_widgets = _general_options_panel(_thumbs_select_clicked, _renders_select_clicked)
+    edit_prefs_panel, edit_prefs_widgets = _edit_prefs_panel()
+    view_pres_panel, view_pref_widgets = _view_prefs_panel()
+    # Jan-2017 - SvdB
+    performance_panel, performance_widgets = _performance_panel()
+
+    notebook = Gtk.Notebook()
+    notebook.set_size_request(PREFERENCES_WIDTH, PREFERENCES_HEIGHT)
+    notebook.append_page(gen_opts_panel, Gtk.Label(label=_("General")))
+    notebook.append_page(edit_prefs_panel, Gtk.Label(label=_("Editing")))
+    notebook.append_page(view_pres_panel, Gtk.Label(label=_("View")))
+    notebook.append_page(performance_panel, Gtk.Label(label=_("Performance")))
+    guiutils.set_margins(notebook, 4, 24, 6, 0)
+
+    dialog.connect('response', _preferences_dialog_callback, (gen_opts_widgets, edit_prefs_widgets, view_pref_widgets, performance_widgets))
+    dialog.vbox.pack_start(notebook, True, True, 0)
+    dialogutils.set_outer_margins(dialog.vbox)
+    dialogutils.default_behaviour(dialog)
+    # Jul-2016 - SvdB - The next line is to get rid of the message "GtkDialog mapped without a transient parent. This is discouraged."
+    dialog.set_transient_for(gui.editor_window.window)
+    dialog.show_all()
+
+def _thumbs_select_clicked(widget):
+    dialogs.select_thumbnail_dir(select_thumbnail_dir_callback, gui.editor_window.window, editorpersistance.prefs.thumbnail_folder, False)
+
+def _renders_select_clicked(widget):
+    dialogs.select_rendred_clips_dir(select_render_clips_dir_callback, gui.editor_window.window, editorpersistance.prefs.render_folder)
+
+def _preferences_dialog_callback(dialog, response_id, all_widgets):
+    if response_id == Gtk.ResponseType.ACCEPT:
+        editorpersistance.update_prefs_from_widgets(all_widgets)
+        editorpersistance.save()
+        dialog.destroy()
+        primary_txt = _("Restart required for some setting changes to take effect.")
+        secondary_txt = _("If requested change is not in effect, restart application.")
+        dialogutils.info_message(primary_txt, secondary_txt, gui.editor_window.window)
+        return
+
+    dialog.destroy()
+
+def _general_options_panel(folder_select_clicked_cb, render_folder_select_clicked_cb):
+    prefs = editorpersistance.prefs
+
+    # Widgets
+    open_in_last_opened_check = Gtk.CheckButton()
+    open_in_last_opened_check.set_active(prefs.open_in_last_opended_media_dir)
+
+    open_in_last_rendered_check = Gtk.CheckButton()
+    open_in_last_rendered_check.set_active(prefs.remember_last_render_dir)
+
+    default_profile_combo = Gtk.ComboBoxText()
+    profiles = mltprofiles.get_profiles()
+    for profile in profiles:
+        default_profile_combo.append_text(profile[0])
+    default_profile_combo.set_active(mltprofiles.get_default_profile_index())
+
+    spin_adj = Gtk.Adjustment(prefs.undos_max, editorpersistance.UNDO_STACK_MIN, editorpersistance.UNDO_STACK_MAX, 1)
+    undo_max_spin = Gtk.SpinButton.new_with_range(editorpersistance.UNDO_STACK_MIN, editorpersistance.UNDO_STACK_MAX, 1)
+    undo_max_spin.set_adjustment(spin_adj)
+    undo_max_spin.set_numeric(True)
+
+    folder_select = Gtk.Button(_("Select Folder")) # thumbnails
+    folder_select.connect("clicked" , folder_select_clicked_cb)
+
+    render_folder_select = Gtk.Button(_("Select Folder"))
+    render_folder_select.connect("clicked" , render_folder_select_clicked_cb)
+
+    autosave_combo = Gtk.ComboBoxText()
+    AUTO_SAVE_OPTS = ((-1, _("No Autosave")),(1, _("1 min")),(2, _("2 min")),(5, _("5 min")))
+
+    for i in range(0, len(AUTO_SAVE_OPTS)):
+        time, desc = AUTO_SAVE_OPTS[i]
+        autosave_combo.append_text(desc)
+    autosave_combo.set_active(prefs.auto_save_delay_value_index)
+
+    load_order_combo  = Gtk.ComboBoxText()
+    load_order_combo.append_text(_("Absolute paths first, relative second"))
+    load_order_combo.append_text(_("Relative paths first, absolute second"))
+    load_order_combo.append_text(_("Absolute paths only"))
+    load_order_combo.set_active(prefs.media_load_order)
+
+    # Layout
+    row1 = _row(guiutils.get_two_column_box(Gtk.Label(label=_("Default Profile:")), default_profile_combo, PREFERENCES_LEFT))
+    row2 = _row(guiutils.get_checkbox_row_box(open_in_last_opened_check, Gtk.Label(label=_("Remember last media directory"))))
+    row3 = _row(guiutils.get_two_column_box(Gtk.Label(label=_("Undo stack size:")), undo_max_spin, PREFERENCES_LEFT))
+    row4 = _row(guiutils.get_two_column_box(Gtk.Label(label=_("Thumbnail folder:")), folder_select, PREFERENCES_LEFT))
+    row5 = _row(guiutils.get_checkbox_row_box(open_in_last_rendered_check, Gtk.Label(label=_("Remember last render directory"))))
+    row6 = _row(guiutils.get_two_column_box(Gtk.Label(label=_("Autosave for crash recovery every:")), autosave_combo, PREFERENCES_LEFT))
+    row8 = _row(guiutils.get_two_column_box(Gtk.Label(label=_("Rendered Clips folder:")), render_folder_select, PREFERENCES_LEFT))
+    row9 = _row(guiutils.get_two_column_box(Gtk.Label(label=_("Media look-up order on load:")), load_order_combo, PREFERENCES_LEFT))
+
+    vbox = Gtk.VBox(False, 2)
+    vbox.pack_start(row1, False, False, 0)
+    vbox.pack_start(row6, False, False, 0)
+    vbox.pack_start(row2, False, False, 0)
+    vbox.pack_start(row5, False, False, 0)
+    vbox.pack_start(row3, False, False, 0)
+    vbox.pack_start(row4, False, False, 0)
+    vbox.pack_start(row8, False, False, 0)
+    vbox.pack_start(row9, False, False, 0)
+    vbox.pack_start(Gtk.Label(), True, True, 0)
+
+    guiutils.set_margins(vbox, 12, 0, 12, 12)
+
+    return vbox, (default_profile_combo, open_in_last_opened_check, open_in_last_rendered_check, undo_max_spin, load_order_combo)
+
+def _edit_prefs_panel():
+    prefs = editorpersistance.prefs
+
+    # Widgets
+    auto_play_in_clip_monitor = Gtk.CheckButton()
+    auto_play_in_clip_monitor.set_active(prefs.auto_play_in_clip_monitor)
+
+    auto_center_on_stop = Gtk.CheckButton()
+    auto_center_on_stop.set_active(prefs.auto_center_on_play_stop)
+
+    spin_adj = Gtk.Adjustment(prefs.default_grfx_length, 1, 15000, 1)
+    gfx_length_spin = Gtk.SpinButton()
+    gfx_length_spin.set_adjustment(spin_adj)
+    gfx_length_spin.set_numeric(True)
+
+    trim_exit_on_empty = Gtk.CheckButton()
+    trim_exit_on_empty.set_active(prefs.empty_click_exits_trims)
+
+    quick_enter_trim = Gtk.CheckButton()
+    quick_enter_trim.set_active(prefs.quick_enter_trims)
+
+    remember_clip_frame = Gtk.CheckButton()
+    remember_clip_frame.set_active(prefs.remember_monitor_clip_frame)
+
+    overwrite_clip_drop = Gtk.ComboBoxText()
+    active = 0
+    if prefs.overwrite_clip_drop == False:
+        active = 1
+    overwrite_clip_drop.append_text(_("Overwrite blanks"))
+    overwrite_clip_drop.append_text(_("Always insert"))
+    overwrite_clip_drop.set_active(active)
+
+    cover_delete = Gtk.CheckButton()
+    cover_delete.set_active(prefs.trans_cover_delete)
+    
+    # Jul-2016 - SvdB - For play_pause button
+    play_pause_button = Gtk.CheckButton()
+    # The following test is to make sure play_pause can be used for the initial value. If not found, then leave uninitialized
+    if hasattr(prefs, 'play_pause'):
+        play_pause_button.set_active(prefs.play_pause)    
+    
+    active = 0
+    if prefs.mouse_scroll_action_is_zoom == False:
+        active = 1
+    mouse_scroll_action = Gtk.ComboBoxText()
+    mouse_scroll_action.append_text(_("Zoom, Control to Scroll Horizontal"))
+    mouse_scroll_action.append_text(_("Scroll Horizontal, Control to Zoom"))
+    mouse_scroll_action.set_active(active)
+
+    hide_file_ext_button = Gtk.CheckButton()
+    if hasattr(prefs, 'hide_file_ext'):
+        hide_file_ext_button.set_active(prefs.hide_file_ext)
+
+    # Layout
+    row1 = _row(guiutils.get_checkbox_row_box(auto_play_in_clip_monitor, Gtk.Label(label=_("Autoplay new Clips in Clip Monitor"))))
+    row2 = _row(guiutils.get_checkbox_row_box(auto_center_on_stop, Gtk.Label(label=_("Center Current Frame on Playback Stop"))))
+    row4 = _row(guiutils.get_two_column_box(Gtk.Label(label=_("Graphics default length:")), gfx_length_spin, PREFERENCES_LEFT))
+    row5 = _row(guiutils.get_checkbox_row_box(trim_exit_on_empty, Gtk.Label(label=_("Trim Modes exit on empty click"))))
+    row6 = _row(guiutils.get_checkbox_row_box(quick_enter_trim, Gtk.Label(label=_("Quick enter Trim Modes"))))
+    row7 = _row(guiutils.get_checkbox_row_box(remember_clip_frame, Gtk.Label(label=_("Remember Monitor Clip Frame"))))
+    row8 = _row(guiutils.get_two_column_box(Gtk.Label(label=_("Media drag'n'drop action on non-V1 tracks")), overwrite_clip_drop, PREFERENCES_LEFT))
+    row9 = _row(guiutils.get_checkbox_row_box(cover_delete, Gtk.Label(label=_("Cover Transition/Fade clips on delete if possible"))))
+    # Jul-2016 - SvdB - For play_pause button
+    row10 = _row(guiutils.get_checkbox_row_box(play_pause_button, Gtk.Label(label=_("Enable single Play/Pause button"))))
+    row11 = _row(guiutils.get_two_column_box(Gtk.Label(label=_("Mouse Middle Button Scroll Action")), mouse_scroll_action, PREFERENCES_LEFT))
+    row12 = _row(guiutils.get_checkbox_row_box(hide_file_ext_button, Gtk.Label(label=_("Hide file extensions when importing Clips"))))
+    
+    vbox = Gtk.VBox(False, 2)
+    vbox.pack_start(row5, False, False, 0)
+    vbox.pack_start(row6, False, False, 0)
+    vbox.pack_start(row1, False, False, 0)
+    vbox.pack_start(row2, False, False, 0)
+    vbox.pack_start(row4, False, False, 0)
+    vbox.pack_start(row7, False, False, 0)
+    vbox.pack_start(row8, False, False, 0)
+    vbox.pack_start(row9, False, False, 0)
+    # Jul-2016 - SvdB - For play_pause button
+    vbox.pack_start(row10, False, False, 0)
+    vbox.pack_start(row11, False, False, 0)
+    vbox.pack_start(row12, False, False, 0)
+    vbox.pack_start(Gtk.Label(), True, True, 0)
+
+    guiutils.set_margins(vbox, 12, 0, 12, 12)
+
+    # Jul-2016 - SvdB - Added play_pause_button
+    return vbox, (auto_play_in_clip_monitor, auto_center_on_stop, gfx_length_spin,
+                  trim_exit_on_empty, quick_enter_trim, remember_clip_frame, overwrite_clip_drop, cover_delete,
+                  play_pause_button, mouse_scroll_action, hide_file_ext_button)
+
+def _view_prefs_panel():
+    prefs = editorpersistance.prefs
+
+    # Widgets
+    force_english_check = Gtk.CheckButton()
+    force_english_check.set_active(prefs.use_english_always)
+
+    display_splash_check = Gtk.CheckButton()
+    display_splash_check.set_active(prefs.display_splash_screen)
+
+    buttons_combo = Gtk.ComboBoxText()
+    buttons_combo.append_text(_("Glass"))
+    buttons_combo.append_text(_("Simple"))
+    if prefs.buttons_style == editorpersistance.GLASS_STYLE:
+        buttons_combo.set_active(0)
+    else:
+        buttons_combo.set_active(1)
+
+    dark_combo = Gtk.ComboBoxText()
+    dark_combo.append_text(_("Light Theme"))
+    dark_combo.append_text(_("Dark Theme"))
+    if prefs.dark_theme == True:
+        dark_combo.set_active(1)
+    else:
+        dark_combo.set_active(0)
+
+    theme_combo = Gtk.ComboBoxText()
+    for theme in gui._THEME_COLORS:
+        theme_combo.append_text(theme[4])
+    theme_combo.set_active(prefs.theme_fallback_colors)
+
+    audio_levels_combo = Gtk.ComboBoxText()
+    audio_levels_combo.append_text(_("Display All Levels"))
+    audio_levels_combo.append_text(_("Display Levels On Request"))
+    if prefs.display_all_audio_levels == True:
+        audio_levels_combo.set_active(0)
+    else:
+        audio_levels_combo.set_active(1)
+
+    window_mode_combo = Gtk.ComboBoxText()
+    window_mode_combo.append_text(_("Single Window"))
+    window_mode_combo.append_text(_("Two Windows"))
+    if prefs.global_layout == appconsts.SINGLE_WINDOW:
+        window_mode_combo.set_active(0)
+    else:
+        window_mode_combo.set_active(1)
+        
+    # Layout
+    row00 = _row(guiutils.get_two_column_box(Gtk.Label(label=_("Application window mode:")), window_mode_combo, PREFERENCES_LEFT))
+    row0 =  _row(guiutils.get_checkbox_row_box(force_english_check, Gtk.Label(label=_("Use English texts on localized OS"))))
+    row1 =  _row(guiutils.get_checkbox_row_box(display_splash_check, Gtk.Label(label=_("Display splash screen"))))
+    row2 =  _row(guiutils.get_two_column_box(Gtk.Label(label=_("Buttons style:")), buttons_combo, PREFERENCES_LEFT))
+    row3 =  _row(guiutils.get_two_column_box(Gtk.Label(label=_("Theme request, icons and colors:")), dark_combo, PREFERENCES_LEFT))
+    row4 =  _row(guiutils.get_two_column_box(Gtk.Label(label=_("Theme detection fail fallback colors:")), theme_combo, PREFERENCES_LEFT))
+    row5 =  _row(guiutils.get_two_column_box(Gtk.Label(label=_("Default audio levels display:")), audio_levels_combo, PREFERENCES_LEFT))
+
+    vbox = Gtk.VBox(False, 2)
+    vbox.pack_start(row00, False, False, 0)
+    vbox.pack_start(row0, False, False, 0)
+    vbox.pack_start(row1, False, False, 0)
+    vbox.pack_start(row2, False, False, 0)
+    vbox.pack_start(row3, False, False, 0)
+    vbox.pack_start(row4, False, False, 0)
+    vbox.pack_start(row5, False, False, 0)
+    vbox.pack_start(Gtk.Label(), True, True, 0)
+
+    guiutils.set_margins(vbox, 12, 0, 12, 12)
+
+    return vbox, (force_english_check, display_splash_check, buttons_combo, dark_combo, theme_combo, audio_levels_combo, window_mode_combo)
+
+def _performance_panel():
+    # Jan-2017 - SvdB
+    # Add a panel for performance settings. The first setting is allowing multiple threads to render
+    # the files. This is used for the real_time parameter to mlt in renderconsumer.py.
+    # The effect depends on the computer running the program.
+    # Max. number of threads is set to number of CPU cores. Default is 1.
+    # Allow Frame Dropping should help getting real time output on low performance computers.
+    prefs = editorpersistance.prefs
+
+    # Widgets
+    spin_adj = Gtk.Adjustment(prefs.perf_render_threads, 1, multiprocessing.cpu_count(), 1)
+    perf_render_threads = Gtk.SpinButton()
+    perf_render_threads.set_adjustment(spin_adj)
+    perf_render_threads.set_numeric(True)
+
+    perf_drop_frames = Gtk.CheckButton()
+    perf_drop_frames.set_active(prefs.perf_drop_frames)
+
+    # Tooltips
+    perf_render_threads.set_tooltip_text(_("Between 1 and the number of CPU Cores"))
+    perf_drop_frames.set_tooltip_text(_("Allow Frame Dropping for real-time rendering, when needed"))
+
+    # Layout
+    row1 = _row(guiutils.get_two_column_box(Gtk.Label(label=_("Render Threads:")), perf_render_threads, PREFERENCES_LEFT))
+    row2 = _row(guiutils.get_checkbox_row_box(perf_drop_frames, Gtk.Label(label=_("Allow Frame Dropping"))))
+
+    vbox = Gtk.VBox(False, 2)
+    vbox.pack_start(row1, False, False, 0)
+    vbox.pack_start(row2, False, False, 0)
+    vbox.pack_start(Gtk.Label(), True, True, 0)
+
+    guiutils.set_margins(vbox, 12, 0, 12, 12)
+
+    return vbox, (perf_render_threads, perf_drop_frames)
+
+def _row(row_cont):
+    row_cont.set_size_request(10, 26)
+    return row_cont

--- a/renderconsumer.py
+++ b/renderconsumer.py
@@ -1,0 +1,532 @@
+"""
+    Flowblade Movie Editor is a nonlinear video editor.
+    Copyright 2012 Janne Liljeblad.
+
+    This file is part of Flowblade Movie Editor <http://code.google.com/p/flowblade>.
+
+    Flowblade Movie Editor is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Flowblade Movie Editor is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Flowblade Movie Editor.  If not, see <http://www.gnu.org/licenses/>.
+"""
+
+"""
+Module contains objects and methods needed to create render consumers.
+"""
+
+
+from gi.repository import Gtk, Gdk
+
+import mlt
+import time
+import threading
+import xml.dom.minidom
+import os
+# Jan-2017 - SvdB
+import editorpersistance
+
+import mltenv
+import respaths
+from editorstate import PLAYER
+from editorstate import PROJECT
+
+# File describing existing encoding and quality options
+RENDER_ENCODING_FILE = "/res/render/renderencoding.xml"
+
+# Node, attribute names.
+NAME = "name"
+TYPE = "type"
+ID = "id"
+EXTENSION = "extension"
+RESIZABLE = "resize"
+ARGS = "args"
+REPLACED_VALUES = "replvalues"
+ADDED_ATTRIBUTES = "addargs"
+BITRATE_OPTION = "boption"
+QUALITY_GROUP = "qualityqroup"
+ENCODING_OPTION = "encodingoption"
+PROXY_ENCODING_OPTION = "proxyencodingoption"
+QGROUP = "qgroup"
+DEFAULT_INDEX = "defaultindex"
+PROFILE = "profile"
+QUALITY = "quality"
+BITRATE = "bitrate"
+AUDIO_DESCRIPTION = "audiodesc"
+NON_USER = "nonuser"
+
+# Replace strings and attribute values
+BITRATE_RPL = "%BITRATE%"
+VARIABLE_VAL = "%VARIABLE%"
+SCREEN_SIZE_RPL = "%SCREENSIZE%"
+ASPECT_RPL = "%ASPECT%"
+
+render_encoding_doc = None
+encoding_options = []
+not_supported_encoding_options = []
+quality_option_groups = {}
+quality_option_groups_default_index = {}
+non_user_encodings = []
+proxy_encodings = None
+
+# replace empty strings with None values
+def _get_attribute(node, attr_name):
+    value = node.getAttribute(attr_name)
+    if value == "":
+        return None
+    
+    return value
+    
+class QualityOption:
+    """
+    A render quality option for an EncodingOption.
+    
+    Values of mlt render consumer properties (usually bitrate) that equal 
+    key expressions are replaced with corresponding values.
+    """
+    def __init__(self, quality_node):
+        self.name = _get_attribute(quality_node, NAME)
+        # Replaced render arguments
+        replaced_values_str = _get_attribute(quality_node, REPLACED_VALUES)
+        self.replaced_expressions = []
+        self.replace_map = {}
+        if replaced_values_str != None:
+            tokens = replaced_values_str.split(";")
+            for token in tokens:
+                token_sides = token.split(" ")
+                self.replaced_expressions.append(token_sides[0])
+                self.replace_map[token_sides[0]] = token_sides[1]
+        # Added render arguments
+        added_atrrs_str = _get_attribute(quality_node, ADDED_ATTRIBUTES)
+        self.add_map = {}
+        if added_atrrs_str != None:
+            tokens = added_atrrs_str.split(" ")
+            for token in tokens:
+                token_sides = token.split("=")
+                self.add_map[token_sides[0]] = token_sides[1]
+
+class EncodingOption:
+    """
+    An object that groups together vcodoc, acodec, format and quality options group.
+    Object is used to set mlt render consumer properties.
+    """
+    def __init__(self, option_node):
+        self.name = _get_attribute(option_node, NAME)
+        self.type = _get_attribute(option_node, TYPE)
+        self.resizable = (_get_attribute(option_node, RESIZABLE) == "True")
+        self.extension = _get_attribute(option_node, EXTENSION)
+        self.nonuser = _get_attribute(option_node, NON_USER)
+        self.quality_qroup_id = _get_attribute(option_node, QGROUP)
+        self.quality_options = quality_option_groups[self.quality_qroup_id]
+        try:
+            quality_default_index = int(quality_option_groups_default_index[self.quality_qroup_id])
+        except KeyError:
+            quality_default_index = None
+        self.quality_default_index = quality_default_index
+        self.audio_desc = _get_attribute(option_node, AUDIO_DESCRIPTION)
+        profile_node = option_node.getElementsByTagName(PROFILE).item(0)
+        self.attr_string =  _get_attribute(profile_node, ARGS)
+        self.acodec = None
+        self.vcodec = None
+        self.format = None
+
+        tokens = self.attr_string.split(" ")
+        for token in tokens:
+            token_sides = token.split("=")
+            if token_sides[0] == "acodec":
+                self.acodec = token_sides[1]
+            elif token_sides[0] == "vcodec":
+                self.vcodec = token_sides[1]
+            elif token_sides[0] == "f":
+                self.format = token_sides[1]
+
+        self.supported, self.err_msg = mltenv.render_profile_supported(self.format, 
+                                                         self.vcodec,
+                                                         self.acodec)
+                                                         
+    def get_args_vals_tuples_list(self, profile, quality_option=None):
+        # Encoding options
+        tokens = self.attr_string.split(" ")
+        args_tuples = []
+        for token in tokens:
+            # Get property keys and values
+            token_sides = token.split("=")
+            arg1 = str(token_sides[0])
+            arg2 = str(token_sides[1])
+            
+            # Replace keyword values
+            if arg2 == SCREEN_SIZE_RPL:
+                arg2 = str(profile.width())+ "x" + str(profile.height())
+            if arg2 == ASPECT_RPL:
+                arg2 = "@" + str(profile.display_aspect_num()) + "/" + str(profile.display_aspect_den())
+
+            # Replace keyword values from quality options values
+            if quality_option != None:
+                if arg2 in quality_option.replaced_expressions:
+                    arg2 = str(quality_option.replace_map[arg2])
+            args_tuples.append((arg1, arg2))
+        
+        return args_tuples
+
+    def get_audio_description(self):
+        if self.audio_desc == None:
+            desc = "Not available"
+        else:
+            desc = self.audio_desc 
+        return "<small>" + desc + "</small>"
+
+    
+def load_render_profiles():
+    """
+    Load render profiles from xml into DOM at start-up and build
+    object tree.
+    """
+    print "Loading render profiles..."
+    file_path = respaths.ROOT_PATH + RENDER_ENCODING_FILE
+    global render_encoding_doc
+    render_encoding_doc = xml.dom.minidom.parse(file_path)
+
+    # Create quality option groups
+    global quality_option_groups
+    qgroup_nodes = render_encoding_doc.getElementsByTagName(QUALITY_GROUP)
+    for qgnode in qgroup_nodes:
+        quality_qroup = []
+        group_key = _get_attribute(qgnode, ID)
+        group_default_index = _get_attribute(qgnode, DEFAULT_INDEX)
+        if group_default_index != None: 
+            quality_option_groups_default_index[group_key] = group_default_index
+        option_nodes = qgnode.getElementsByTagName(QUALITY)
+        for option_node in option_nodes:
+            q_option = QualityOption(option_node)
+            quality_qroup.append(q_option)
+        quality_option_groups[group_key] = quality_qroup
+
+    # Create encoding options
+    global encoding_options, not_supported_encoding_options, non_user_encodings
+    encoding_option_nodes = render_encoding_doc.getElementsByTagName(ENCODING_OPTION)
+    for eo_node in encoding_option_nodes:
+        encoding_option = EncodingOption(eo_node)
+        if encoding_option.supported:
+            if encoding_option.nonuser == None:
+                encoding_options.append(encoding_option)
+            else:
+                non_user_encodings.append(encoding_option) 
+        else:
+            msg = "...NOT available, " + encoding_option.err_msg + " missing"
+            not_supported_encoding_options.append(encoding_option)
+            print encoding_option.name + msg
+
+    # Proxy encoding
+    proxy_encoding_nodes = render_encoding_doc.getElementsByTagName(PROXY_ENCODING_OPTION)
+    found_proxy_encodings = []
+    for proxy_node in proxy_encoding_nodes:
+        proxy_encoding_option = EncodingOption(proxy_node)
+        if proxy_encoding_option.supported:
+            msg = " ...available"
+            found_proxy_encodings.append(proxy_encoding_option)
+        else:
+            msg = " ...NOT available, " + encoding_option.err_msg + " missing"
+        print "Proxy encoding " + proxy_encoding_option.name + msg
+    global proxy_encodings
+    proxy_encodings = found_proxy_encodings
+
+def get_render_consumer_for_encoding_and_quality(file_path, profile, enc_opt_index, quality_opt_index):
+    args_vals_list = get_args_vals_tuples_list_for_encoding_and_quality(profile,
+                                                                       enc_opt_index,
+                                                                       quality_opt_index)
+        
+    return get_mlt_render_consumer(file_path, profile, args_vals_list)
+
+def get_render_consumer_for_encoding(file_path, profile, encoding_option):
+    # Encoding options key, value list
+    args_vals_list = encoding_option.get_args_vals_tuples_list(profile)
+
+    return get_mlt_render_consumer(file_path, profile, args_vals_list)
+
+def get_render_consumer_for_text_buffer(file_path, profile, buf):
+    args_vals_list, error = get_ffmpeg_opts_args_vals_tuples_list(buf)
+    if error != None:
+        return (None, error)
+
+    render_consumer = get_mlt_render_consumer(file_path, profile, args_vals_list)
+    return (render_consumer, None)
+
+def get_img_seq_render_consumer(file_path, profile, encoding_option):
+    #render_path = "%1/%2-%05d.%3" + file_path
+    args_vals_list = encoding_option.get_args_vals_tuples_list(profile)
+    
+    vcodec = None
+    for arg_val in args_vals_list:
+        arg, val = arg_val
+        if arg == "vcodec":
+            vcodec = val
+
+    render_path = os.path.dirname(file_path) + "/" + os.path.basename(file_path).split(".")[0] + "_%05d." + encoding_option.extension
+    
+    consumer = mlt.Consumer(profile, "avformat", str(render_path))
+    # Jan-2017 - SvdB - perf_value instead of -1
+    if editorpersistance.prefs.perf_drop_frames == True:
+        perf_value = 1 * editorpersistance.prefs.perf_render_threads
+    else:
+        perf_value = -1 * editorpersistance.prefs.perf_render_threads
+    consumer.set("real_time", perf_value)
+    consumer.set("rescale", "bicubic")
+    consumer.set("vcodec", str(vcodec))
+    print "img seq render consumer created, path:" +  str(render_path) #+ ", args: " + args_msg
+    return consumer
+    
+def get_mlt_render_consumer(file_path, profile, args_vals_list):
+    consumer = mlt.Consumer(profile, "avformat", str(file_path))
+    # Jan-2017 - SvdB - perf_value instead of -1
+    if editorpersistance.prefs.perf_drop_frames == True:
+        perf_value = 1 * editorpersistance.prefs.perf_render_threads
+    else:
+        perf_value = -1 * editorpersistance.prefs.perf_render_threads
+    consumer.set("real_time", perf_value)
+    consumer.set("rescale", "bicubic")
+
+    args_msg = ""
+    for arg_val in args_vals_list:
+        k, v = arg_val
+        consumer.set(str(k), str(v))
+        args_msg = args_msg + str(k) + "="+ str(v) + ", "
+        
+    args_msg = args_msg.strip(", ")
+    print "render consumer created, path:" +  str(file_path) + ", args: " + args_msg
+    return consumer
+
+def get_args_vals_tuples_list_for_encoding_and_quality(profile, enc_opt_index, quality_opt_index):
+    encoding_option = encoding_options[enc_opt_index]
+    if quality_opt_index >= 0:
+        quality_option = encoding_option.quality_options[quality_opt_index]
+    else:
+        quality_option = None
+
+    args_vals_list = encoding_option.get_args_vals_tuples_list(profile, quality_option)
+
+    # Quality options  key, value list
+    if quality_option != None:
+        for k, v in quality_option.add_map.iteritems():
+            args_vals_list.append((str(k), str(v)))
+    
+    return args_vals_list
+
+def get_video_non_user_encodigs():
+    video_non_user_encs = []
+    for enc in non_user_encodings:
+        if enc.type != "audio":
+            video_non_user_encs.append(enc)
+
+    return video_non_user_encs
+
+def get_ffmpeg_opts_args_vals_tuples_list(buf):
+    end = buf.get_end_iter()
+    arg_vals = []
+    for i in range(0, buf.get_line_count()):
+        line_start = buf.get_iter_at_line(i)
+        if i == buf.get_line_count() - 1:
+            line_end = end
+        else:
+            line_end = buf.get_iter_at_line(i + 1)
+        av_tuple, error = _parse_line(line_start, line_end, buf)
+        if error != None:
+            errs_str = _("Error on line ") + str(i + 1) + ": " + error + _("\nLine contents: ") \
+                       + buf.get_text(line_start, line_end, include_hidden_chars=False)
+            return (None, errs_str)
+        if av_tuple != None:
+            arg_vals.append(av_tuple)
+    
+    return (arg_vals, None)
+
+def _parse_line(line_start, line_end, buf):
+    line = buf.get_text(line_start, line_end, include_hidden_chars=False)
+    if len(line) == 0:
+        return (None, None)
+    if line.find("=") == -1:
+        return (None, _("No \'=\' found."))
+    sides = line.split("=")
+    if len(sides) != 2:
+        return (None, _("Number of tokens on line is ")+ str(len(sides)) + _(", should be 2 (key, value)."))
+    k = sides[0].strip()
+    v = sides[1].strip()
+    if len(k) == 0:
+        return (None, _("Arg name token is empty."))
+    if len(v) == 0:
+        return (None, _("Arg value token is empty."))
+    try:
+        k.decode('ascii')
+    except UnicodeDecodeError:
+        return (None, _("Non-ascii char in Arg name."))
+    try:
+        v.decode('ascii')
+    except UnicodeDecodeError:
+        return (None, _("Non-ascii char in Arg value."))
+    if k.find(" ") != -1:
+        return (None,  _("Whitespace in Arg name."))
+    if v.find(" ") != -1:
+        return (None,  _("Whitespace in Arg value."))
+        
+    return ((k,v), None)
+
+
+class FileRenderPlayer(threading.Thread):
+    def __init__(self, file_name, producer, consumer, start_frame, stop_frame):
+        self.file_name = file_name
+        self.producer = producer
+        self.consumer = consumer
+        self.start_frame = start_frame
+        self.stop_frame = stop_frame
+        self.stopped = False
+        self.wait_for_producer_end_stop = True
+        self.running = False
+        self.has_started_running = False
+        print "FileRenderPlayer started, start frame: " + str(self.start_frame) + ", stop frame: " + str(self.stop_frame)
+        self.consumer_pos_stop_add = 1 # HACK!!! File renders work then this is one, screenshot render requires this to be 2 to work 
+        threading.Thread.__init__(self)
+
+    def run(self):
+        self.running = True
+        self.has_started_running = True
+        self.connect_and_start()
+
+        while self.running: # set false at shutdown() for abort
+            if self.producer.frame() >= self.stop_frame:
+                # This method of stopping makes sure that whole producer is rendered and written to disk
+                # Used when producer out frame is last frame.
+                if self.wait_for_producer_end_stop:
+                    while self.producer.get_speed() > 0:
+                        time.sleep(0.2)
+                    while not self.consumer.is_stopped():
+                        time.sleep(0.2)
+                # This method of stopping stops producer
+                # and waits for consumer to reach that frame.
+                # Used when producer out frame is NOT last frame.
+                else:
+                    self.producer.set_speed(0)
+                    last_frame = self.producer.frame()
+                    while self.consumer.position() + self.consumer_pos_stop_add < last_frame:
+                        time.sleep(0.2)
+
+                    self.consumer.stop()
+                                        
+                self.running = False
+
+            time.sleep(0.1)
+
+        print "FileRenderPlayer stopped, producer frame: " + str(self.producer.frame())
+
+        self.stopped = True
+                
+    def shutdown(self):
+        self.consumer.stop()
+        self.producer.set_speed(0)
+        self.running = False
+
+    def connect_and_start(self):
+        self.consumer.connect(self.producer)
+        self.producer.set_speed(0)
+        self.producer.seek(self.start_frame)
+        self.producer.set_speed(1)
+        self.consumer.start()
+
+    def get_render_fraction(self):
+        render_length = self.stop_frame - self.start_frame + 1
+        if (self.producer.get_length() - 1) < 1:
+            render_fraction = 1.0
+        else:
+            current_frame = self.producer.frame() - self.start_frame
+            render_fraction = (float(current_frame)) / (float(render_length))
+        if render_fraction > 1.0:
+            render_fraction = 1.0
+        return render_fraction
+
+
+class XMLRenderPlayer(threading.Thread):
+    def __init__(self, file_name, callback, data):
+        self.file_name = file_name
+        self.render_done_callback = callback
+        self.data = data
+        self.current_playback_frame = 0
+
+        threading.Thread.__init__(self)
+
+    def run(self):
+        print "Starting XML render"
+        player = PLAYER()
+        
+        # Don't try anything if somehow this was started 
+        # while timeline rendering is running
+        if player.is_rendering:
+            print "Can't render XML when another render is already running!"
+            return
+
+        # Stop all playback before producer is disconnected
+        self.current_playback_frame = player.producer.frame()
+        player.ticker.stop_ticker()
+        player.consumer.stop()
+        player.producer.set_speed(0)
+        player.producer.seek(0)
+        
+        # Wait until producer is at start
+        while player.producer.frame() != 0:
+            time.sleep(0.1)
+        
+        # Get render producer
+        timeline_producer = PROJECT().c_seq.tractor
+
+        # Get render consumer
+        xml_consumer = mlt.Consumer(PROJECT().profile, "xml", str(self.file_name))
+
+        # Connect and start rendering
+        xml_consumer.connect(timeline_producer)
+        xml_consumer.start()
+        timeline_producer.set_speed(1)
+
+        # Wait until done
+        while xml_consumer.is_stopped() == False:
+            print "In XML render wait loop..."
+            time.sleep(0.1)
+    
+        print "XML render done"
+
+        # Get app player going again
+        player.connect_and_start()
+        player.seek_frame(0)
+
+        self.render_done_callback(self.data)
+
+
+class ProgressWindowThread(threading.Thread):
+    def __init__(self, dialog, progress_bar, clip_renderer, callback):
+        self.dialog = dialog
+        self.progress_bar = progress_bar
+        self.clip_renderer = clip_renderer
+        self.callback = callback
+        threading.Thread.__init__(self)
+    
+    def run(self):        
+        self.running = True
+        
+        while self.running:         
+            render_fraction = self.clip_renderer.get_render_fraction()
+            Gdk.threads_enter()
+            self.progress_bar.set_fraction(render_fraction)
+            pros = int(render_fraction * 100)
+            self.progress_bar.set_text(str(pros) + "%")
+            Gdk.threads_leave()
+            if self.clip_renderer.stopped == True:
+                Gdk.threads_enter()
+                self.progress_bar.set_fraction(1.0)
+                self.progress_bar.set_text("Render Complete!")
+                self.callback(self.dialog, 0)
+                Gdk.threads_leave()
+                self.running = False
+
+            time.sleep(0.33)


### PR DESCRIPTION
Changes include:

1) New Preferences tab 'Performance'
2) Performance options 'Render Threads' (limited to the number of cores as reported by the system - default 1) and 'Allow Frame Dropping' (default False)
3) Options under 2) will be passed as value to the mlt consumer real_time parameter. Allow Frame Dropping translates to 1 (True) or -1 (False) and is multiplied by the number of render threads