### PR TITLE
Filenames in Media-List - issue 267

### DIFF
--- a/flowblade-trunk/Flowblade/editorpersistance.py
+++ b/flowblade-trunk/Flowblade/editorpersistance.py
@@ -179,7 +179,7 @@ def update_prefs_from_widgets(widgets_tuples_tuple):
         trim_exit_click, trim_quick_enter, remember_clip_frame, overwrite_clip_drop, cover_delete, \
         play_pause_button, mouse_scroll_action, hide_file_ext_button = edit_prefs_widgets
     
-    use_english, disp_splash, buttons_style, dark_theme, theme_combo, audio_levels_combo, window_mode_combo = view_prefs_widgets
+    use_english, disp_splash, buttons_style, dark_theme, theme_combo, audio_levels_combo, window_mode_combo, full_names = view_prefs_widgets
 
     # Jan-2017 - SvdB
     perf_render_threads, perf_drop_frames = performance_widgets
@@ -214,6 +214,8 @@ def update_prefs_from_widgets(widgets_tuples_tuple):
     # Jan-2017 - SvdB
     prefs.perf_render_threads = int(perf_render_threads.get_adjustment().get_value())
     prefs.perf_drop_frames = perf_drop_frames.get_active()
+    # Feb-2017 - SvdB - for full file names
+    prefs.show_full_file_names = full_names.get_active()
 
 def get_graphics_default_in_out_length():
     in_fr = int(15000/2) - int(prefs.default_grfx_length/2)
@@ -297,3 +299,5 @@ class EditorPreferences:
         # Jan-2017 - SvdB
         self.perf_render_threads = 1
         self.perf_drop_frames = False
+        # Feb-2017 - SvdB - for full file names
+        self.show_full_file_names = False

--- a/flowblade-trunk/Flowblade/guicomponents.py
+++ b/flowblade-trunk/Flowblade/guicomponents.py
@@ -926,8 +926,14 @@ class MediaObjectWidget:
 
         txt = Gtk.Label(label=media_file.name)
         txt.modify_font(Pango.FontDescription("sans 9"))
-        txt.set_ellipsize(Pango.EllipsizeMode.END)
         txt.set_max_width_chars(13)
+        # Feb-2017 - SvdB - For full file names. First part shows the original code for short file names        
+        if editorpersistance.prefs.show_full_file_names == False:
+            txt.set_ellipsize(Pango.EllipsizeMode.END)
+        else:
+            txt.set_line_wrap_mode(Pango.WrapMode.CHAR)
+            txt.set_line_wrap(True)
+        # end SvdB
         txt.set_tooltip_text(media_file.name)
 
         self.vbox.pack_start(self.img, True, True, 0)

--- a/flowblade-trunk/Flowblade/mltprofiles.py
+++ b/flowblade-trunk/Flowblade/mltprofiles.py
@@ -61,10 +61,20 @@ def _load_profiles_list(dir_path):
     load_profiles = []
     file_list = os.listdir(dir_path)
     for fname in file_list:
+        # Feb-2017 - SvdB - Filter out duplicate profiles based on profile name
+        found_duplicate = False
+        
         file_path = dir_path + fname
         profile = mlt.Profile(file_path)
         profile.file_path = file_path
-        load_profiles.append([profile.description(), profile])
+        
+        # Feb-2017 - SvdB - Filter out duplicate profiles based on profile name
+        for enu_count, prof in enumerate(load_profiles):
+            for prof_idx, prof_name in enumerate(prof):
+                if prof_name == profile.description():
+                    found_duplicate = True
+        if found_duplicate == False:
+            load_profiles.append([profile.description(), profile])
     
     return load_profiles
 

--- a/flowblade-trunk/Flowblade/preferenceswindow.py
+++ b/flowblade-trunk/Flowblade/preferenceswindow.py
@@ -250,6 +250,10 @@ def _view_prefs_panel():
     display_splash_check = Gtk.CheckButton()
     display_splash_check.set_active(prefs.display_splash_screen)
 
+    # Feb-2017 - SvdB - For full file names
+    show_full_file_names = Gtk.CheckButton()
+    show_full_file_names.set_active(prefs.show_full_file_names)
+
     buttons_combo = Gtk.ComboBoxText()
     buttons_combo.append_text(_("Glass"))
     buttons_combo.append_text(_("Simple"))
@@ -295,6 +299,8 @@ def _view_prefs_panel():
     row3 =  _row(guiutils.get_two_column_box(Gtk.Label(label=_("Theme request, icons and colors:")), dark_combo, PREFERENCES_LEFT))
     row4 =  _row(guiutils.get_two_column_box(Gtk.Label(label=_("Theme detection fail fallback colors:")), theme_combo, PREFERENCES_LEFT))
     row5 =  _row(guiutils.get_two_column_box(Gtk.Label(label=_("Default audio levels display:")), audio_levels_combo, PREFERENCES_LEFT))
+    # Feb-2017 - SvdB - For full file names
+    row6 =  _row(guiutils.get_checkbox_row_box(show_full_file_names, Gtk.Label(label=_("Show Full File names"))))
 
     vbox = Gtk.VBox(False, 2)
     vbox.pack_start(row00, False, False, 0)
@@ -304,11 +310,15 @@ def _view_prefs_panel():
     vbox.pack_start(row3, False, False, 0)
     vbox.pack_start(row4, False, False, 0)
     vbox.pack_start(row5, False, False, 0)
+    # Feb-2017 - SvdB - For full file names
+    vbox.pack_start(row6, False, False, 0)
     vbox.pack_start(Gtk.Label(), True, True, 0)
 
     guiutils.set_margins(vbox, 12, 0, 12, 12)
 
-    return vbox, (force_english_check, display_splash_check, buttons_combo, dark_combo, theme_combo, audio_levels_combo, window_mode_combo)
+    # Feb-2017 - SvdB - Added code for full file names
+    return vbox, (force_english_check, display_splash_check, buttons_combo, dark_combo, theme_combo, audio_levels_combo, 
+                  window_mode_combo, show_full_file_names)
 
 def _performance_panel():
     # Jan-2017 - SvdB


### PR DESCRIPTION
Preference setting (In View tab) to show full file names in the media list.
When unticked (Default) it will show as it is now, when ticked all files will show their full file name.
No need to restart the application. Setting will be activated once a file is added or removed in the media list.