### PR TITLE
Unpickling...¿? #341

### DIFF
--- a/flowblade-trunk/Flowblade/persistance.py
+++ b/flowblade-trunk/Flowblade/persistance.py
@@ -352,7 +352,8 @@ def load_project(file_path, icons_and_thumnails=True, relinker_load=False):
 
     if(not hasattr(project, "SAVEFILE_VERSION")):
         project.SAVEFILE_VERSION = 1 # first save files did not have this
-    print "Loading " + project.name + ", SAVEFILE_VERSION:", project.SAVEFILE_VERSION
+    # SvdB - Feb-2017 - Removed project.name from print. It causes problems with non-latin characters, in some cases. Not sure why, yet.
+    print "Loading Project, SAVEFILE_VERSION:", project.SAVEFILE_VERSION
 
     # Set MLT profile. NEEDS INFO USER ON MISSING PROFILE!!!!!
     project.profile = mltprofiles.get_profile(project.profile_desc)


### PR DESCRIPTION
Removed print of project.name in the debugging message. This will allow the project to load if it has non-latin characters in the name.
No real reason found why it is a problem, but any manipulation on project.name (If it contains non-latin characters, like characters with tilde, accents, cedilles etc.) causes the project load to stop.