### PR TITLE
Thumbnail icon for flb project files? #346

### DIFF
--- a/flowblade-trunk/installdata/flowblade.xml
+++ b/flowblade-trunk/installdata/flowblade.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <mime-info xmlns='http://www.freedesktop.org/standards/shared-mime-info'>
-  <mime-type type="application/vnd.flowblade-project">
+  <mime-type type="application/flowblade">
     <comment>Flowblade project</comment>
     <glob pattern="*.flb"/>
   </mime-type>


### PR DESCRIPTION
Slight change in xml file should associate Flowblade logo to flb files.

To test manually, update flowblade.xml in /usr/share/mime/packages
and then run
sudo update-mime-database /usr/share/mime/
then open file browser and flb files should have the Flowblade logo associated to them.

To revert, revert the changes to flowblade.xml and rerun
sudo update-mime-database /usr/share/mime/
close and re-open the file browser and the flb files have the current logo.