### PR TITLE
Add Lossless FFv1 profile

### DIFF
--- a/flowblade-trunk/Flowblade/res/render/renderencoding.xml
+++ b/flowblade-trunk/Flowblade/res/render/renderencoding.xml
@@ -91,6 +91,9 @@
     <encodingoption name="Lossless H.264 / .mp4" extension="mp4" audiodesc=" aac"  type="av" resize="True" qgroup="lossless">
         <profile args="f=mp4 acodec=aac ab=384k ac=2 pix_fmt=yuv420p vcodec=libx264 cqp=0 me_method=esa subq=8 qmin=10 qcomp=0.6 qdiff=4 qmax=51 coder=ac partitions=+parti4x4+parti8x8+partp4x4+partp8x8+partb8x8 refs=16 trellis=1" />
     </encodingoption>
+    <encodingoption name="Lossless FFv1 / .mkv" extension="mkv" audiodesc=" flac"  type="av" resize="True" qgroup="lossless">
+        <profile args="f=mkv acodec=flac vcodec=ffv1 level=3 g=1 slicecrc=1 slices=16" />
+    </encodingoption>
     <encodingoption name="Apple ProRes 4:2:2 / .mov" extension="mov" audiodesc=" pcm" type="av" resize="True" qgroup="variablenooption">
     <profile args="f=mov acodec=pcm_s16le ac=2 vcodec=prores vb=0 g=0 bf=0 threads=1 vprofile=2" />
     </encodingoption>


### PR DESCRIPTION
Encoding parameters taken from https://amiaopensource.github.io/ffmprovisr/#create_FFV1_mkv