### PR TITLE
Standard shortkey

### DIFF
--- a/flowblade-trunk/Flowblade/keyevents.py
+++ b/flowblade-trunk/Flowblade/keyevents.py
@@ -276,7 +276,7 @@ def _handle_tline_key_event(event):
     # Key bindings for MOVE MODES and _NO_EDIT modes
     if editorstate.current_is_move_mode() or editorstate.current_is_active_trim_mode() == False:
          # UP ARROW, next cut
-        if event.keyval == Gdk.KEY_Up:
+        if event.keyval == Gdk.KEY_Down:
             if editorstate.timeline_visible():
                 tline_frame = PLAYER().tracktor_producer.frame()
                 frame = current_sequence().find_next_cut_frame(tline_frame)
@@ -289,7 +289,7 @@ def _handle_tline_key_event(event):
                 monitorevent.up_arrow_seek_on_monitor_clip()
         
         # DOWN ARROW, prev cut
-        if event.keyval == Gdk.KEY_Down:
+        if event.keyval == Gdk.KEY_Up:
             if editorstate.timeline_visible():
                 tline_frame = PLAYER().tracktor_producer.frame()
                 frame = current_sequence().find_prev_cut_frame(tline_frame)

--- a/flowblade-trunk/Flowblade/keyevents.py
+++ b/flowblade-trunk/Flowblade/keyevents.py
@@ -275,7 +275,18 @@ def _handle_tline_key_event(event):
 
     # Key bindings for MOVE MODES and _NO_EDIT modes
     if editorstate.current_is_move_mode() or editorstate.current_is_active_trim_mode() == False:
-         # UP ARROW, next cut
+
+        # MINUS, zoom out
+        if event.keyval == Gdk.KEY_minus:
+            updater.zoom_out()
+
+        # EQUAL (PLUS), zoom in
+        if event.keyval == Gdk.KEY_equal:
+            updater.zoom_in()
+
+
+
+        # UP ARROW, next cut
         if event.keyval == Gdk.KEY_Down:
             if editorstate.timeline_visible():
                 tline_frame = PLAYER().tracktor_producer.frame()


### PR DESCRIPTION
Initially my aim is to bring the keyboard shortcuts from FCP and Premiere to Flowblade.
My suggestions till now:
- Replace functionality of Arrow Up and Down
- Add + and - key functionality for timeline zoom in and out (actually = and - on keyboard)

It seems the Up/Down arrow functionality needs to be implemented in a long run (for compatibility) Perhaps we can work on it later