### PR TITLE
Support for manual entered time codes

### DIFF
--- a/flowblade-trunk/Flowblade/editorwindow.py
+++ b/flowblade-trunk/Flowblade/editorwindow.py
@@ -1028,7 +1028,7 @@ class EditorWindow:
         return buttons_row
 
     def _add_tool_tips(self):
-        self.big_TC.widget.set_tooltip_text(_("Timeline current frame timecode"))
+        self.big_TC.set_tooltip_text(_("Timeline current frame timecode"))
 
         self.view_mode_select.widget.set_tooltip_text(_("Select view mode: Video/Vectorscope/RGBParade"))
         

--- a/flowblade-trunk/Flowblade/guicomponents.py
+++ b/flowblade-trunk/Flowblade/guicomponents.py
@@ -1838,6 +1838,8 @@ class BigTCDisplay:
         self.TEXT_X = 18
         self.TEXT_Y = 1
 
+        self.widget.connect("button-press-event", self._button_press)
+
     def _draw(self, event, cr, allocation):
         """
         Callback for repaint from CairoDrawableArea.
@@ -1891,6 +1893,54 @@ class BigTCDisplay:
         cr.arc (x + radius, y + height - radius, radius, 90 * degrees, 180 * degrees)
         cr.arc (x + radius, y + radius, radius, 180 * degrees, 270 * degrees)
         cr.close_path ()
+
+    def _button_press(self, widget, event):
+        gui.big_tc.set_visible_child_name("BigTCEntry")
+        entry = gui.big_tc.get_visible_child()
+        entry.set_text(BigTCEntry().get_current_frame_text())
+        entry.grab_focus()
+
+    def _seek_frame(self, frame):
+        PLAYER().seek_frame(frame)
+
+class BigTCEntry:
+    """
+    Test class for replacement of BigTCDisplay, when Editing time position
+    """
+
+    def __init__(self):
+        self.widget = Gtk.Entry()
+        frame_str = self.get_current_frame_text()
+        self.widget.set_text(frame_str)
+        self.widget.connect("activate", self._enter_pressed)
+        self.widget.connect("focus-out-event", self._focus_lost)
+        self.widget.connect("focus", self._focus_received)
+
+    def get_current_frame_text(self):
+        try:
+            frame = PLAYER().tracktor_producer.frame()
+            frame_str = utils.get_tc_string(frame)
+        except:
+            frame_str = "00:00:00:00"
+        return frame_str
+
+    def _handle_set_time(self):
+        self.visible = False
+        frame_str = gui.big_tc.get_visible_child().get_text()
+        frame = utils.get_tc_frame(frame_str)
+        gui.big_tc.set_visible_child_name("BigTCDisplay")
+        PLAYER().seek_frame(int(frame))
+
+    def _enter_pressed(self, event):
+        self._handle_set_time()
+
+    def _focus_lost(self, widget, event):
+        if self.visible:
+            self._handle_set_time()
+
+    def _focus_received(self, widget, event):
+        self.visible = True
+
 
 
 class MonitorTCDisplay:

--- a/flowblade-trunk/Flowblade/middlebar.py
+++ b/flowblade-trunk/Flowblade/middlebar.py
@@ -117,7 +117,10 @@ def create_edit_buttons_row_buttons(editor_window, modes_pixbufs):
 
 def _create_buttons(editor_window):
     IMG_PATH = respaths.IMAGE_PATH
-    editor_window.big_TC = guicomponents.BigTCDisplay()
+    editor_window.big_TC = Gtk.Stack()
+    editor_window.big_TC.add_named(guicomponents.BigTCDisplay().widget, "BigTCDisplay")
+    editor_window.big_TC.add_named(guicomponents.BigTCEntry().widget, "BigTCEntry")
+    editor_window.big_TC.set_visible_child_name("BigTCDisplay")
     gui.big_tc = editor_window.big_TC 
     editor_window.modes_selector = guicomponents.ToolSelector(editor_window.mode_selector_pressed, m_pixbufs, 40, 22)
 
@@ -170,7 +173,7 @@ def _create_buttons(editor_window):
 def fill_with_TC_LEFT_pattern(buttons_row, window):
     global w
     w = window
-    buttons_row.pack_start(w.big_TC.widget, False, True, 0)
+    buttons_row.pack_start(w.big_TC, False, True, 0)
     buttons_row.pack_start(guiutils.get_pad_label(7, MIDDLE_ROW_HEIGHT), False, True, 0) #### NOTE!!!!!! THIS DETERMINES THE HEIGHT OF MIDDLE ROW
     buttons_row.pack_start(w.modes_selector.widget, False, True, 0)
     if editorstate.SCREEN_WIDTH > 1279:
@@ -213,7 +216,7 @@ def fill_with_TC_MIDDLE_pattern(buttons_row, window):
     left_panel.pack_start(Gtk.Label(), True, True, 0)
 
     middle_panel = Gtk.HBox(False, 0) 
-    middle_panel.pack_start(w.big_TC.widget, False, True, 0)
+    middle_panel.pack_start(w.big_TC, False, True, 0)
     middle_panel.pack_start(guiutils.get_pad_label(10, 10), False, True, 0)
     middle_panel.pack_start(w.modes_selector.widget, False, True, 0)
     
@@ -235,7 +238,7 @@ def fill_with_COMPONETS_CENTERED_pattern(buttons_row, window):
     global w
     w = window
     buttons_row.pack_start(Gtk.Label(), True, True, 0)
-    buttons_row.pack_start(w.big_TC.widget, False, True, 0)
+    buttons_row.pack_start(w.big_TC, False, True, 0)
     buttons_row.pack_start(guiutils.get_pad_label(7, MIDDLE_ROW_HEIGHT), False, True, 0) #### NOTE!!!!!! THIS DETERMINES THE HEIGHT OF MIDDLE ROW
     buttons_row.pack_start(w.modes_selector.widget, False, True, 0)
     if editorstate.SCREEN_WIDTH > 1279:

--- a/flowblade-trunk/Flowblade/updater.py
+++ b/flowblade-trunk/Flowblade/updater.py
@@ -527,7 +527,7 @@ def update_frame_displayers(frame):
 
     gui.tline_scale.widget.queue_draw()
     gui.tline_canvas.widget.queue_draw()
-    gui.big_tc.widget.queue_draw()
+    gui.big_tc.queue_draw()
     clipeffectseditor.display_kfeditors_tline_frame(frame)
     compositeeditor.display_kfeditors_tline_frame(frame)
 

--- a/flowblade-trunk/Flowblade/utils.py
+++ b/flowblade-trunk/Flowblade/utils.py
@@ -125,6 +125,37 @@ def get_tc_string(frame):
     """
     return get_tc_string_with_fps(frame, fps())
 
+def get_tc_frame(frame_str):
+    """
+    Return timecode frame from string
+    """
+    return get_tc_frame_with_fps(frame_str, fps())
+
+def get_tc_frame_with_fps(frame_str, frames_per_sec):
+    # split time string hh:mm:ss:ff into integer and
+    # calculate corresponding frame
+    try:
+        times = frame_str.split(":", 4)
+    except expression as identifier:
+        return 0
+
+    # now we calculate the sum of frames that would sum up at corresponding
+    # time
+    sum = 0
+    for t in times:
+        num = int(t)
+        sum = sum * 60 + num
+
+    # but well, actually, calculated sum is wrong, because according
+    # to our calculation, that would give us 60 fps, we need to correct that
+    # last 'num' is frames already, no need to correct those
+    sum = sum - num
+    sum = sum / (60 / int(round(frames_per_sec)))
+    sum = sum + num
+
+    # and that is our frame, so we return sum
+    return sum
+
 def get_tc_string_with_fps(frame, frames_per_sec):
     # convert fractional frame rates (like 23.976) into integers,
     # otherwise the timeline will slowly drift over time


### PR DESCRIPTION
- Added a GtkEntry class named BigTCEntry that offers functionality for manually entering a time code to jump to.
- Replaced editor_window.big_TC and gui.big_tc with GtkStack containing BigTCDisplay.widget and BigTCEntry.widget
- implemented a mouse click event handler on BigTCDisplay that makes BigTCEntry visible, when clicked on BigTCDisplay
- implemtented a enter pressed and focus lost event handler that will make PLAYER() jump to entered time code and make BigTCDisplay visible again

General Description:
When time display in middlebar is clicked an entry field will be displayed instead, that offers you the possibility to manually enter a time code.
You may leave the entry by pressing TAB or ENTER. The cursor will jump to frame of timecode if valid.

Things that might still need attention:
There is no validation of timecode, nor is ensured that only times ranging from hour, minute, seconds, frame min to max are accepted. Instead e.g. 71 minutes will be automatically (due to way of calculation) converted in corresponding frame of 1:11:00:00 (one hour, eleven minutes).
Time codes that have less than four fields will be interpreted as if with leading zero fields: 1:5 is equivalent to 00:00:01:05.
Timecodes with more than four time fields will not be interpreted correctly.
Format has to be HH:mm:ss:ff, but is not strictly validated.
Exception is caught though and will result in no jump.

	modified:       flowblade-trunk/Flowblade/editorwindow.py
	modified:       flowblade-trunk/Flowblade/guicomponents.py
	modified:       flowblade-trunk/Flowblade/middlebar.py
	modified:       flowblade-trunk/Flowblade/updater.py
	modified:       flowblade-trunk/Flowblade/utils.py

I am open for improvements, adaptions, suggestions, fixes... I just can't tell when I will get to them.