### PR TITLE
add appdata

### DIFF
--- a/flowblade-trunk/installdata/flowblade.appdata.xml
+++ b/flowblade-trunk/installdata/flowblade.appdata.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop">
+	<id>flowblade.desktop</id>
+	<metadata_license>CC0-1.0</metadata_license>
+	<project_license>GPL-3.0+</project_license>
+	<name>Flowblade</name>
+	<url type="homepage">https://jliljebl.github.io/flowblade</url>
+	<summary>Video Editor - Fast, Precise, Stable</summary>
+	<description>
+		<p>Flowblade is a multitrack non-linear video editor released under GPL3 license.
+        From beginners to masters, Flowblade helps make your vision a reality of image and sound.</p>
+	</description>
+	<screenshots>
+		<screenshot type="default">
+			<image>https://raw.githubusercontent.com/jliljebl/flowblade/master/flowblade-trunk/docs/Screenshot-1-4-dark.png</image>
+		</screenshot>
+		<screenshot>
+			<image>https://raw.githubusercontent.com/jliljebl/flowblade/master/flowblade-trunk/docs/Screenshot-0-18.png</image>
+		</screenshot>
+	</screenshots>
+	<releases>
+		<release version="1.16" date="2018-03-31"/>
+  	</releases>
+	<content_rating type="oars-1.0">
+		<content_attribute id="violence-cartoon">none</content_attribute>
+		<content_attribute id="violence-fantasy">none</content_attribute>
+		<content_attribute id="violence-realistic">none</content_attribute>
+		<content_attribute id="violence-bloodshed">none</content_attribute>
+		<content_attribute id="violence-sexual">none</content_attribute>
+		<content_attribute id="drugs-alcohol">none</content_attribute>
+		<content_attribute id="drugs-narcotics">none</content_attribute>
+		<content_attribute id="drugs-tobacco">none</content_attribute>
+		<content_attribute id="sex-nudity">none</content_attribute>
+		<content_attribute id="sex-themes">none</content_attribute>
+		<content_attribute id="language-profanity">none</content_attribute>
+		<content_attribute id="language-humor">none</content_attribute>
+		<content_attribute id="language-discrimination">none</content_attribute>
+		<content_attribute id="social-chat">none</content_attribute>
+		<content_attribute id="social-info">none</content_attribute>
+		<content_attribute id="social-audio">none</content_attribute>
+		<content_attribute id="social-location">none</content_attribute>
+		<content_attribute id="social-contacts">none</content_attribute>
+		<content_attribute id="money-purchasing">none</content_attribute>
+		<content_attribute id="money-gambling">none</content_attribute>
+	</content_rating>
+</component>

--- a/flowblade-trunk/setup.py
+++ b/flowblade-trunk/setup.py
@@ -25,6 +25,7 @@ from distutils.core import setup
 # FLOWBLADE distutils setup.py script.
 
 install_data = [('share/applications', ['installdata/flowblade.desktop']),
+                ('share/appdata', ['installdata/flowblade.appdata.xml']),
                 ('share/pixmaps', ['installdata/flowblade.png']),
                 ('share/mime/packages',['installdata/flowblade.xml']),
                 ('lib/mime/packages',['installdata/flowblade']),


### PR DESCRIPTION
This file is used in software managers like GNOME Software or KDE Discover to display information. It is also used on Flathub: https://flathub.org/apps/details/io.github.jliljebl.Flowblade