### PR TITLE
Add Solus to DEPENDENCIES.md

### DIFF
--- a/flowblade-trunk/docs/DEPENDENCIES.md
+++ b/flowblade-trunk/docs/DEPENDENCIES.md
@@ -36,4 +36,3 @@
 | python-gnome2 |  0.6   |  1.2 |
 | python-gobject-2 |  0.6   |  1.2 |
 | python-cairo |  0.6   |  1.6 |
-.

--- a/flowblade-trunk/docs/DEPENDENCIES.md
+++ b/flowblade-trunk/docs/DEPENDENCIES.md
@@ -1,23 +1,28 @@
 # Flowblade Package Dependencies #
 
-| **Debian/Ubuntu package name** | **Description** | **Archlinux packages** |
-|:-------------------------------|:----------------|:--------------|
-| python-gi | GTK3 Python bindings | pygtk |
-| python-mlt | MLT python bindings, this pulls in MLT | mlt-python-bindings |
-| python-dbus | dbus python bindings | python2-dbus |
-| libmlt-data | Some image and text resources for MLT | mlt, sdl_image |
-| python 2.7 >=| Language and interpreter | python2 |
-| frei0r-plugins | Additional video filters | movit, frei0r-plugins |
-| swh-plugins | Additional audio filters | sox, swh-plugins |
-| python-gi-cairo | Gi Cairo bindings | python2-gobject |
-| python-numpy | Math and arrays library | python2-numpy |
-| python-pil | PIL image manipulation library | python2-pillow |
-| librsvg2-common | svg support | librsvg |
-| gmic | framework for image processing | gmic |
-| gir1.2-glib-2.0 | Glib | dbus-glib |
-| gir1.2-gtk-3.0 | Gtk toolkit | gtk3 |
-| gir1.2-pango-1.0 | Pango text lib | pango |
-| gir1.2-gdkpixbuf-2.0 | Image support | gdk-pixbuf2 |
+| **Debian/Ubuntu package name** | **Description** | **Archlinux packages** | **Solus packages** |
+|:-------------------------------|:----------------|:--------------|:---------------|
+| python-gi | GTK3 Python bindings | pygtk | ??? |
+| mlt | | | (compile from source¹) |
+| python-mlt | MLT python bindings, this pulls in MLT | mlt-python-bindings | (comes with mlt sources²) |
+| python-dbus | dbus python bindings | python2-dbus | python-dbus |
+| libmlt-data | Some image and text resources for MLT | mlt, sdl_image | mlt, sdl1-image |
+| python >= 2.7 < 3 | Language and interpreter | python2 | python |
+| frei0r-plugins | Additional video filters | movit, frei0r-plugins | movit, frei0r |
+| swh-plugins | Additional audio filters | sox, swh-plugins | sox, swh-plugins |
+| python-gi-cairo | Gi Cairo bindings | python2-gobject | python-gobject |
+| python-numpy | Math and arrays library | python2-numpy | numpy |
+| python-pil | PIL image manipulation library | python2-pillow | python-pillow |
+| librsvg2-common | svg support | librsvg | librsvg |
+| gmic | framework for image processing | gmic | gmic |
+| gir1.2-glib-2.0 | Glib | dbus-glib | dbus-glib |
+| gir1.2-gtk-3.0 | Gtk toolkit | gtk3 | libgtk-3 |
+| gir1.2-pango-1.0 | Pango text lib | pango | pango |
+| gir1.2-gdkpixbuf-2.0 | Image support | gdk-pixbuf2 | gdk-pixbuf |
+| | | | cairo |
+
+¹ Version supplied by package manager lacks python bindings. Needs `{sox,frei0r,libexif,movit,sdl1,sdl1-image,alsa-lib,pulseaudio}-devel` to build.
+² Patch `src/swig/python/build` to use `python2` instead of `python`, then run `configure` with `--swig-languages=python`. Before running `make install`, add `cp python/_mlt.so python/mlt.py python/mlt_wrap.o '$(prefix)/lib/python2.7/'` to `src/swig/Makefile`'s `install` rule.
 
 # Dropped  Dependencies #
 
@@ -30,3 +35,4 @@
 | python-gnome2 |  0.6   |  1.2 |
 | python-gobject-2 |  0.6   |  1.2 |
 | python-cairo |  0.6   |  1.6 |
+.

--- a/flowblade-trunk/docs/DEPENDENCIES.md
+++ b/flowblade-trunk/docs/DEPENDENCIES.md
@@ -3,8 +3,8 @@
 | **Debian/Ubuntu package name** | **Description** | **Archlinux packages** | **Solus packages** |
 |:-------------------------------|:----------------|:--------------|:---------------|
 | python-gi | GTK3 Python bindings | pygtk | python-gobject |
-| mlt | | | (compile from source¹) |
-| python-mlt | MLT python bindings, this pulls in MLT | mlt-python-bindings | (comes with mlt sources²) |
+| mlt | Multimedia framework | mlt | (compile from source¹) |
+| python-mlt | MLT python bindings | mlt-python-bindings | (comes with mlt sources²) |
 | python-dbus | dbus python bindings | python2-dbus | python-dbus |
 | libmlt-data | Some image and text resources for MLT | mlt, sdl_image | mlt, sdl1-image |
 | python >= 2.7 < 3 | Language and interpreter | python2 | python |

--- a/flowblade-trunk/docs/DEPENDENCIES.md
+++ b/flowblade-trunk/docs/DEPENDENCIES.md
@@ -19,7 +19,7 @@
 | gir1.2-gtk-3.0 | Gtk toolkit | gtk3 | libgtk-3 |
 | gir1.2-pango-1.0 | Pango text lib | pango | pango |
 | gir1.2-gdkpixbuf-2.0 | Image support | gdk-pixbuf2 | gdk-pixbuf |
-| | | | cairo |
+| cairo | 2D graphics library | cairo | cairo |
 
 ¹ Version supplied by package manager lacks python bindings. Needs `{sox,frei0r,libexif,movit,sdl1,sdl1-image,alsa-lib,pulseaudio}-devel` to build.
 

--- a/flowblade-trunk/docs/DEPENDENCIES.md
+++ b/flowblade-trunk/docs/DEPENDENCIES.md
@@ -2,7 +2,7 @@
 
 | **Debian/Ubuntu package name** | **Description** | **Archlinux packages** | **Solus packages** |
 |:-------------------------------|:----------------|:--------------|:---------------|
-| python-gi | GTK3 Python bindings | pygtk | ??? |
+| python-gi | GTK3 Python bindings | pygtk | python-gobject |
 | mlt | | | (compile from source¹) |
 | python-mlt | MLT python bindings, this pulls in MLT | mlt-python-bindings | (comes with mlt sources²) |
 | python-dbus | dbus python bindings | python2-dbus | python-dbus |
@@ -22,6 +22,7 @@
 | | | | cairo |
 
 ¹ Version supplied by package manager lacks python bindings. Needs `{sox,frei0r,libexif,movit,sdl1,sdl1-image,alsa-lib,pulseaudio}-devel` to build.
+
 ² Patch `src/swig/python/build` to use `python2` instead of `python`, then run `configure` with `--swig-languages=python`. Before running `make install`, add `cp python/_mlt.so python/mlt.py python/mlt_wrap.o '$(prefix)/lib/python2.7/'` to `src/swig/Makefile`'s `install` rule.
 
 # Dropped  Dependencies #


### PR DESCRIPTION
I'm trying to get Flowblade running on [Solus](https://getsol.us/home/) without having to resort to the Flatpak you provide. Getting the dependencies sorted out took a while, but I believe with the exception of `mlt` missing its Python bindings everything is there.

Unfortunately, running `python2 flowblade-trunk/flowblade` results in a segfault right after the `Create SDL1 consumer...` message. If there's any advice you might have on that it would be much appreciated :-)