### PR TITLE
Undefined name: 'expression' is never defined

### DIFF
--- a/flowblade-trunk/Flowblade/utils.py
+++ b/flowblade-trunk/Flowblade/utils.py
@@ -155,7 +155,7 @@ def get_tc_frame_with_fps(frame_str, frames_per_sec):
     # calculate corresponding frame
     try:
         times = frame_str.split(":", 4)
-    except expression as identifier:
+    except Exception:
         return 0
 
     # now we calculate the sum of frames that would sum up at corresponding


### PR DESCRIPTION
__expression__ is never defined and __identifier__ is never used.

$ __flake8 . --builtins=\_ --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./flowblade-trunk/Flowblade/utils.py:158:12: F821 undefined name 'expression'
    except expression as identifier:
           ^
```