### PR TITLE
from gi.repository import Gdk for lines 63 and 65

### DIFF
--- a/flowblade-trunk/Flowblade/jackaudio.py
+++ b/flowblade-trunk/Flowblade/jackaudio.py
@@ -26,6 +26,8 @@ import os
 import threading
 import time
 
+from gi.repository import Gdk
+
 import appconsts
 import dialogutils
 import editorpersistance


### PR DESCRIPTION
$ __flake8 . --builtins=\_ --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./flowblade-trunk/Flowblade/jackaudio.py:61:9: F821 undefined name 'Gdk'
        Gdk.threads_enter()
        ^
./flowblade-trunk/Flowblade/jackaudio.py:63:9: F821 undefined name 'Gdk'
        Gdk.threads_leave()
        ^
```