### PR TITLE
Undefined name: global undo_stack, index in undo.py

### DIFF
--- a/flowblade-trunk/Flowblade/undo.py
+++ b/flowblade-trunk/Flowblade/undo.py
@@ -147,18 +147,19 @@ def _set_post_edit_mode():
         set_post_undo_redo_edit_mode()
 
 def undo_redo_stress_test():
+    global undo_stack, index
     times = 10
     delay = 0.100
     
     for r in range(0, times):
-        while undo.index > 0:
-            print "undo:", undo.index
+        while index > 0:
+            print "undo:", index
             do_undo()
 
             time.sleep(delay)
     
-        while undo.index < len(undo.undo_stack):
-            print "redo:", undo.index
+        while index < len(undo_stack):
+            print "redo:", index
             do_redo()
 
             time.sleep(delay)


### PR DESCRIPTION
Make line 150 like line 50.

$ __flake8 . --builtins=\_ --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./flowblade-trunk/Flowblade/undo.py:154:15: F821 undefined name 'undo'
        while undo.index > 0:
              ^
./flowblade-trunk/Flowblade/undo.py:155:28: F821 undefined name 'undo'
            print "undo:", undo.index
                           ^
./flowblade-trunk/Flowblade/undo.py:160:15: F821 undefined name 'undo'
        while undo.index < len(undo.undo_stack):
              ^
./flowblade-trunk/Flowblade/undo.py:160:32: F821 undefined name 'undo'
        while undo.index < len(undo.undo_stack):
                               ^
./flowblade-trunk/Flowblade/undo.py:161:28: F821 undefined name 'undo'
            print "redo:", undo.index
                           ^
```