### PR TITLE
Uncomment line 174 for lines 175, 176, 178

### DIFF
--- a/flowblade-trunk/Flowblade/jackaudio.py
+++ b/flowblade-trunk/Flowblade/jackaudio.py
@@ -171,7 +171,7 @@ class JackAudioManagerDialog:
         vbox.pack_start(props_frame, False, False, 0)
         vbox.pack_start(onoff_frame, False, False, 0)
 
-        #alignment = Gtk.Alignment.new(0.5, 0.5, 1.0, 1.0)
+        alignment = Gtk.Alignment.new(0.5, 0.5, 1.0, 1.0)
         alignment.set_padding(12, 12, 12, 12)
         alignment.add(vbox)
 


### PR DESCRIPTION
When line 174 was commented out, it created _undefined names_ on lines 175, 176, and 178.  An alternative approach would be to comment out all four lines.

$ __flake8 . --builtins=\_ --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./flowblade-trunk/Flowblade/jackaudio.py:148:59: F821 undefined name '_convert_to_original_media_project'
        self.dont_use_button.connect("clicked", lambda w: _convert_to_original_media_project())
                                                          ^
./flowblade-trunk/Flowblade/jackaudio.py:175:9: F821 undefined name 'alignment'
        alignment.set_padding(12, 12, 12, 12)
        ^
./flowblade-trunk/Flowblade/jackaudio.py:176:9: F821 undefined name 'alignment'
        alignment.add(vbox)
        ^
./flowblade-trunk/Flowblade/jackaudio.py:178:37: F821 undefined name 'alignment'
        self.dialog.vbox.pack_start(alignment, True, True, 0)
                                    ^
```