### PR TITLE
import userfolders to fix proxy rendering and misc typos

### DIFF
--- a/flowblade-trunk/Flowblade/diskcachemanagement.py
+++ b/flowblade-trunk/Flowblade/diskcachemanagement.py
@@ -169,9 +169,9 @@ def _get_disk_dir_panels():
     panels = []
     panels.append(DiskFolderManagementPanel(appconsts.AUDIO_LEVELS_DIR, _("Audio Levels Data"), RECREATE_WARNING))
     panels.append(DiskFolderManagementPanel(appconsts.GMIC_DIR, _("G'Mic Tool Session Data"), NO_WARNING))
-    # FIXME: code assumes that all these are in samo root folder, not anymore, 
+    # FIXME: code assumes that all these are in same root folder, not anymore, 
     #panels.append(DiskFolderManagementPanel(appconsts.RENDERED_CLIPS_DIR, _("Rendered Files"), PROJECT_DATA_WARNING))
     panels.append(DiskFolderManagementPanel(appconsts.THUMBNAILS_DIR, _("Thumbnails"), RECREATE_WARNING))
-    panels.append(DiskFolderManagementPanel(appcossts.USER_PROFILES_DIR_NO_SLASH, _("User Created Custom Profiles"), PROJECT_DATA_WARNING))
+    panels.append(DiskFolderManagementPanel(appconsts.USER_PROFILES_DIR_NO_SLASH, _("User Created Custom Profiles"), PROJECT_DATA_WARNING))
 
     return panels

--- a/flowblade-trunk/Flowblade/proxyediting.py
+++ b/flowblade-trunk/Flowblade/proxyediting.py
@@ -42,7 +42,7 @@ import render
 import renderconsumer
 import sequence
 import utils
-
+import userfolders
 
 manager_window = None
 progress_window = None


### PR DESCRIPTION
This fixes the traceback error in issue #660 and proxy files are rendering without any errors.