### PR TITLE
setup.py: Add use_2to3=True parameter to setup()

### DIFF
--- a/flowblade-trunk/setup.py
+++ b/flowblade-trunk/setup.py
@@ -52,5 +52,5 @@ setup(  name='flowblade',
         scripts=['flowblade'],
         packages=['Flowblade','Flowblade/tools','Flowblade/vieweditor'],
         package_data={'Flowblade':flowblade_package_data + locale_files},
-        data_files=install_data)
-
+        data_files=install_data,
+        use_2to3=True)


### PR DESCRIPTION
When attempting to __pip3 install flowblade__, setup.py will automatically convert legacy __print__ statements and old style exceptions to be syntax compatible with Python 3.  This change will have no effect when doing __pip2 install flowblade__.  For details see: https://setuptools.readthedocs.io/en/latest/python3.html

@martinkg