### PR TITLE
Change calls to file() into calls to open()

### DIFF
--- a/flowblade-trunk/Flowblade/audiowaveform.py
+++ b/flowblade-trunk/Flowblade/audiowaveform.py
@@ -148,7 +148,7 @@ class WaveformCreator(threading.Thread):
 
         if not self.abort:
             self.clip.waveform_data = frame_levels
-            write_file = file(self.file_cache_path, "wb")
+            write_file = open(self.file_cache_path, "wb")
             pickle.dump(frame_levels, write_file)
 
             Gdk.threads_enter()
@@ -214,4 +214,3 @@ def _waveform_render_progress_dialog(callback, title, text, progress_bar, parent
     dialog.connect('response', callback)
     dialog.show()
     return dialog
-

--- a/flowblade-trunk/Flowblade/audiowaveformrenderer.py
+++ b/flowblade-trunk/Flowblade/audiowaveformrenderer.py
@@ -222,7 +222,7 @@ class WaveformCreator(threading.Thread):
             frame_levels[frame] = float(val)
             self.last_rendered_frame = frame
 
-        write_file = file(self.file_cache_path, "wb")
+        write_file = open(self.file_cache_path, "wb")
         pickle.dump(frame_levels, write_file)
 
     def _get_temp_producer(self, clip_path, profile):
@@ -237,7 +237,3 @@ class WaveformCreator(threading.Thread):
         self.clip_media_length = temp_producer.get_length()
 
         return temp_producer
-
-
-
-

--- a/flowblade-trunk/Flowblade/editorpersistance.py
+++ b/flowblade-trunk/Flowblade/editorpersistance.py
@@ -62,7 +62,7 @@ def load():
         prefs = pickle.load(f)
     except:
         prefs = EditorPreferences()
-        write_file = file(prefs_file_path, "wb")
+        write_file = open(prefs_file_path, "wb")
         pickle.dump(prefs, write_file)
 
     # Override deprecated preferences to default values.
@@ -78,7 +78,7 @@ def load():
     except:
         recent_projects = utils.EmptyClass()
         recent_projects.projects = []
-        write_file = file(recents_file_path, "wb")
+        write_file = open(recents_file_path, "wb")
         pickle.dump(recent_projects, write_file)
 
     # Remove non-existing projects from recents list
@@ -90,7 +90,7 @@ def load():
     if len(remove_list) > 0:
         for proj_path in remove_list:
             recent_projects.projects.remove(proj_path)
-        write_file = file(recents_file_path, "wb")
+        write_file = open(recents_file_path, "wb")
         pickle.dump(recent_projects, write_file)
         
     # Versions of program may have different prefs objects and 
@@ -101,7 +101,7 @@ def load():
     if len(prefs.__dict__) != len(current_prefs.__dict__):
         current_prefs.__dict__.update(prefs.__dict__)
         prefs = current_prefs
-        write_file = file(prefs_file_path, "wb")
+        write_file = open(prefs_file_path, "wb")
         pickle.dump(prefs, write_file)
         print "prefs updated to new version, new param count:", len(prefs.__dict__)
 
@@ -112,10 +112,10 @@ def save():
     prefs_file_path = userfolders.get_config_dir()+ PREFS_DOC
     recents_file_path = userfolders.get_config_dir() + RECENT_DOC
     
-    write_file = file(prefs_file_path, "wb")
+    write_file = open(prefs_file_path, "wb")
     pickle.dump(prefs, write_file)
 
-    write_file = file(recents_file_path, "wb")
+    write_file = open(recents_file_path, "wb")
     pickle.dump(recent_projects, write_file)
 
 def add_recent_project_path(path):
@@ -151,7 +151,7 @@ def remove_non_existing_recent_projects():
     if len(remove_list) > 0:
         for proj_path in remove_list:
             recent_projects.projects.remove(proj_path)
-        write_file = file(recents_file_path, "wb")
+        write_file = open(recents_file_path, "wb")
         pickle.dump(recent_projects, write_file)
         
 def fill_recents_menu_widget(menu_item, callback):

--- a/flowblade-trunk/Flowblade/gui.py
+++ b/flowblade-trunk/Flowblade/gui.py
@@ -222,7 +222,7 @@ def save_current_colors():
     # Used to communicate theme colors to tools like gmic.py running on separate process
     colors = (unpack_gdk_color(_selected_bg_color), unpack_gdk_color(_bg_color), unpack_gdk_color(_button_colors))
     save_file_path = _colors_data_path()
-    write_file = file(save_file_path, "wb")
+    write_file = open(save_file_path, "wb")
     pickle.dump(colors, write_file)
 
 def load_current_colors():

--- a/flowblade-trunk/Flowblade/tools/batchrendering.py
+++ b/flowblade-trunk/Flowblade/tools/batchrendering.py
@@ -539,11 +539,11 @@ class BatchRenderItemData:
 
     def save(self):
         item_path = get_datafiles_dir() + self.generate_identifier() + ".renderitem"
-        item_write_file = file(item_path, "wb")
+        item_write_file = open(item_path, "wb")
         pickle.dump(self, item_write_file)
 
     def save_as_single_render_item(self, item_path):
-        item_write_file = file(item_path, "wb")
+        item_write_file = open(item_path, "wb")
         pickle.dump(self, item_write_file)
 
     def delete_from_queue(self):

--- a/flowblade-trunk/Flowblade/tools/titler.py
+++ b/flowblade-trunk/Flowblade/tools/titler.py
@@ -173,7 +173,7 @@ class TitlerData:
         save_data = copy.deepcopy(self)
         for layer in save_data.layers:
             layer.pango_layout = None
-        write_file = file(save_file_path, "wb")
+        write_file = open(save_file_path, "wb")
         pickle.dump(save_data, write_file)
    
     def create_pango_layouts(self):


### PR DESCRIPTION
__file()__ was removed in Python 3 in favor of __open()__ which works as expected in both Python 2 and 3.

$ __2to3 -w .__  # Also see #669
$ __python3 -m flake8 . --builtins=\_  --count --select=E9,F63,F72,F82 --show-source --statistics__
```
./flowblade-trunk/Flowblade/audiowaveformrenderer.py:225:22: F821 undefined name 'file'
        write_file = file(self.file_cache_path, "wb")
                     ^
./flowblade-trunk/Flowblade/audiowaveform.py:151:26: F821 undefined name 'file'
            write_file = file(self.file_cache_path, "wb")
                         ^
./flowblade-trunk/Flowblade/gui.py:225:18: F821 undefined name 'file'
    write_file = file(save_file_path, "wb")
                 ^
./flowblade-trunk/Flowblade/editorpersistance.py:65:22: F821 undefined name 'file'
        write_file = file(prefs_file_path, "wb")
                     ^
./flowblade-trunk/Flowblade/editorpersistance.py:81:22: F821 undefined name 'file'
        write_file = file(recents_file_path, "wb")
                     ^
./flowblade-trunk/Flowblade/editorpersistance.py:93:22: F821 undefined name 'file'
        write_file = file(recents_file_path, "wb")
                     ^
./flowblade-trunk/Flowblade/editorpersistance.py:104:22: F821 undefined name 'file'
        write_file = file(prefs_file_path, "wb")
                     ^
./flowblade-trunk/Flowblade/editorpersistance.py:115:18: F821 undefined name 'file'
    write_file = file(prefs_file_path, "wb")
                 ^
./flowblade-trunk/Flowblade/editorpersistance.py:118:18: F821 undefined name 'file'
    write_file = file(recents_file_path, "wb")
                 ^
./flowblade-trunk/Flowblade/editorpersistance.py:154:22: F821 undefined name 'file'
        write_file = file(recents_file_path, "wb")
                     ^
./flowblade-trunk/Flowblade/tools/titler.py:176:22: F821 undefined name 'file'
        write_file = file(save_file_path, "wb")
                     ^
./flowblade-trunk/Flowblade/tools/batchrendering.py:542:27: F821 undefined name 'file'
        item_write_file = file(item_path, "wb")
                          ^
./flowblade-trunk/Flowblade/tools/batchrendering.py:546:27: F821 undefined name 'file'
        item_write_file = file(item_path, "wb")
                          ^
13    F821 undefined name 'file'
13
```