### PR TITLE
Undefined names: Add missing imports

### DIFF
--- a/flowblade-trunk/Flowblade/diskcachemanagement.py
+++ b/flowblade-trunk/Flowblade/diskcachemanagement.py
@@ -24,6 +24,7 @@ from os import listdir
 from os.path import isfile, join
 import os
 
+import appconsts
 import dialogutils
 import gui
 import guiutils

--- a/flowblade-trunk/Flowblade/tlineaction.py
+++ b/flowblade-trunk/Flowblade/tlineaction.py
@@ -66,6 +66,7 @@ import respaths
 import sequence
 import syncsplitevent
 import updater
+import userfolders
 import utils
 
 

--- a/flowblade-trunk/Flowblade/tools/phantomcompositor.py
+++ b/flowblade-trunk/Flowblade/tools/phantomcompositor.py
@@ -23,6 +23,7 @@ import sys
 
 from gi.repository import Gtk
 
+import appconsts
 import dialogutils
 import editorstate
 import guiutils

--- a/flowblade-trunk/Flowblade/userfolders.py
+++ b/flowblade-trunk/Flowblade/userfolders.py
@@ -26,6 +26,8 @@ import os
 import threading
 
 import appconsts
+import mltprofiles
+import utils
 
 USING_DOT_DIRS = 0 # This is only used during testing and if user forces .dot dirs.
 USING_XDG_DIRS = 1
@@ -137,10 +139,10 @@ def _maybe_create_dot_dirs():
         os.mkdir(user_dir)
     if not os.path.exists(user_dir + mltprofiles.USER_PROFILES_DIR):
         os.mkdir(user_dir + mltprofiles.USER_PROFILES_DIR)
-    if not os.path.exists(user_dir + AUTOSAVE_DIR):
-        os.mkdir(user_dir + AUTOSAVE_DIR)
-    if not os.path.exists(user_dir + BATCH_DIR):
-        os.mkdir(user_dir + BATCH_DIR)
+    if not os.path.exists(user_dir + appconsts.AUTOSAVE_DIR):
+        os.mkdir(user_dir + appconsts.AUTOSAVE_DIR)
+    if not os.path.exists(user_dir + appconsts.BATCH_DIR):
+        os.mkdir(user_dir + appconsts.BATCH_DIR)
     if not os.path.exists(user_dir + appconsts.AUDIO_LEVELS_DIR):
         os.mkdir(user_dir + appconsts.AUDIO_LEVELS_DIR)
     if not os.path.exists(utils.get_hidden_screenshot_dir_path()):


### PR DESCRIPTION
[flake8](http://flake8.pycqa.org) testing of https://github.com/jliljebl/flowblade on Python 2.7.15

$ __flake8 . --builtins=_ --count --select=E9,F63,F72,F82 --show-source --statistics__
```
./flowblade-trunk/Flowblade/userfolders.py:138:38: F821 undefined name 'mltprofiles'
    if not os.path.exists(user_dir + mltprofiles.USER_PROFILES_DIR):
                                     ^
./flowblade-trunk/Flowblade/userfolders.py:139:29: F821 undefined name 'mltprofiles'
        os.mkdir(user_dir + mltprofiles.USER_PROFILES_DIR)
                            ^
./flowblade-trunk/Flowblade/userfolders.py:140:38: F821 undefined name 'AUTOSAVE_DIR'
    if not os.path.exists(user_dir + AUTOSAVE_DIR):
                                     ^
./flowblade-trunk/Flowblade/userfolders.py:141:29: F821 undefined name 'AUTOSAVE_DIR'
        os.mkdir(user_dir + AUTOSAVE_DIR)
                            ^
./flowblade-trunk/Flowblade/userfolders.py:142:38: F821 undefined name 'BATCH_DIR'
    if not os.path.exists(user_dir + BATCH_DIR):
                                     ^
./flowblade-trunk/Flowblade/userfolders.py:143:29: F821 undefined name 'BATCH_DIR'
        os.mkdir(user_dir + BATCH_DIR)
                            ^
./flowblade-trunk/Flowblade/userfolders.py:146:27: F821 undefined name 'utils'
    if not os.path.exists(utils.get_hidden_screenshot_dir_path()):
                          ^
./flowblade-trunk/Flowblade/userfolders.py:147:18: F821 undefined name 'utils'
        os.mkdir(utils.get_hidden_screenshot_dir_path())
                 ^
./flowblade-trunk/Flowblade/diskcachemanagement.py:170:45: F821 undefined name 'appconsts'
    panels.append(DiskFolderManagementPanel(appconsts.AUDIO_LEVELS_DIR, _("Audio Levels Data"), RECREATE_WARNING))
                                            ^
./flowblade-trunk/Flowblade/diskcachemanagement.py:171:45: F821 undefined name 'appconsts'
    panels.append(DiskFolderManagementPanel(appconsts.GMIC_DIR, _("G'Mic Tool Session Data"), NO_WARNING))
                                            ^
./flowblade-trunk/Flowblade/diskcachemanagement.py:174:45: F821 undefined name 'appconsts'
    panels.append(DiskFolderManagementPanel(appconsts.THUMBNAILS_DIR, _("Thumbnails"), RECREATE_WARNING))
                                            ^
./flowblade-trunk/Flowblade/diskcachemanagement.py:175:45: F821 undefined name 'appconsts'
    panels.append(DiskFolderManagementPanel(appconsts.USER_PROFILES_DIR_NO_SLASH, _("User Created Custom Profiles"), PROJECT_DATA_WARNING))
                                            ^
./flowblade-trunk/Flowblade/tlineaction.py:1568:18: F821 undefined name 'userfolders'
        folder = userfolders.get_render_dir()
                 ^
./flowblade-trunk/Flowblade/tools/phantomcompositor.py:70:76: F821 undefined name 'appconsts'
                        + " cachefolder "  + userfolders.get_cache_dir() + appconsts.PHANTOM_DIR + "/" + appconsts.PHANTOM_DISK_CACHE_DIR], shell=True, stdin=FLOG, stdout=FLOG, stderr=FLOG)
                                                                           ^
./flowblade-trunk/Flowblade/tools/phantomcompositor.py:70:106: F821 undefined name 'appconsts'
                        + " cachefolder "  + userfolders.get_cache_dir() + appconsts.PHANTOM_DIR + "/" + appconsts.PHANTOM_DISK_CACHE_DIR], shell=True, stdin=FLOG, stdout=FLOG, stderr=FLOG)
                                                                                                         ^
15    F821 undefined name 'appconsts'
15
```
__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. These 5 are different from most other flake8 issues which are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree