### PR TITLE
Change launch script for variant install locations

### DIFF
--- a/flowblade-trunk/flowblade
+++ b/flowblade-trunk/flowblade
@@ -34,7 +34,7 @@ print "Launch script dir:", launch_dir
 
 # Update sys.path to include modules
 # When running on distro
-if launch_dir == "/usr/bin":
+if launch_dir in {"bin", "/usr/bin", "/usr/local/bin"}:
     print "Running from installation..."
     modules_path = "/usr/share/flowblade/Flowblade"
     if not os.path.isdir(modules_path):


### PR DESCRIPTION
This ensures that even if flowblade is installed in /bin or /usr/local/bin that it finds the modules correctly and is able to launch. Otherwise, it cannot find the processutils module and does not launch.

I apologize for submitting this during the project summer break. Please do not start on addressing this until August.

Thank you for any reply, and please let me know if there is anything I have missed.