### PR TITLE
Fix Lut3D file type regression

### DIFF
--- a/flowblade-trunk/Flowblade/res/filters/filters.xml
+++ b/flowblade-trunk/Flowblade/res/filters/filters.xml
@@ -673,7 +673,7 @@
     <filter id="avfilter.lut3d">
         <name>Lut3D</name>
         <group>Color</group>
-        <property name="av.file" args="editor=file_select exptype=file_resource file_types=.cube,.CUBE displayname=Select!.cube!file">/this/is/placeholder/value.cube</property>
+        <property name="av.file" args="editor=file_select exptype=file_resource file_types=.cube.CUBE displayname=Select!.cube!file">/this/is/placeholder/value.cube</property>
    </filter>
    
    


### PR DESCRIPTION
This commit fixes a regression where .cube files (lowercase)
could not be loaded in the Lut3D filter.

The ability for the Lut3D filter to load .cube files stopped
working. I traced this back to a formatting mismatch between
the following two files:

  flowblade-trunk/Flowblade/propertyeditorbuilder.py
  flowblade-trunk/Flowblade/res/filters/filters.xml

When propertyeditorbuilder.py loads lists of file types to use
when filtering results in the GTK file picker, it is expecting
to find them as a string with a dot preceeding each file
extension, e.g.: ".cube.CUBE"

The filters.xml file only currently has one file_types setting,
and it is for the Lut3D filter. Before this commit, it had the
file types for 3D LUT file extensions specified with a comma
separating them, e.g. ".cube,.CUBE"

This prevented the .cube files from showing up in the file
selection dialog box, because it was actually looking for ".cube,"
files instead.