### PR TITLE
Remove left over Python 2 string decode() calls

### DIFF
--- a/flowblade-trunk/Flowblade/renderconsumer.py
+++ b/flowblade-trunk/Flowblade/renderconsumer.py
@@ -387,14 +387,6 @@ def _parse_line(line_start, line_end, buf):
         return (None, _("Arg name token is empty."))
     if len(v) == 0:
         return (None, _("Arg value token is empty."))
-    try:
-        k.decode('ascii')
-    except UnicodeDecodeError:
-        return (None, _("Non-ascii char in Arg name."))
-    try:
-        v.decode('ascii')
-    except UnicodeDecodeError:
-        return (None, _("Non-ascii char in Arg value."))
     if k.find(" ") != -1:
         return (None,  _("Whitespace in Arg name."))
     if v.find(" ") != -1:

--- a/flowblade-trunk/Flowblade/tools/gmic.py
+++ b/flowblade-trunk/Flowblade/tools/gmic.py
@@ -115,7 +115,6 @@ def get_gmic_version():
     tokens = output.split()
     clended = []
     for token in tokens:
-        token = token.decode("utf-8") 
         str1 = token.replace('.','')
         str2 = str1.replace(',','')
         if str2.isdigit(): # this is based on assumtion that str2 ends up being number like "175" or 215" etc. only for version number token


### PR DESCRIPTION
I tried to render a movie using custom render args from Flowblade
on the master branch. However, it bumped into a decode() call on
a string.

This would have worked on Python 2. But decode() is no longer a
valid method on strings in Python 3.

There were two main instances of this:

1) A key and value in renderconsumer.py, which were previously
   being checked to ensure they were in ASCII format

2) A decode() call on a string in gmic.py

I removed all of these decode() calls in this commit, but I'm not
completely sure that everything is correct.

For one thing, it is now possible to have non-ASCII characters
get through in renderconsumer.py. I'm not sure if that's an issue
or not. This commit just removes those decode() calls, but if they
still need to be ASCII, then something else should be put in place
of the code that was removed. On the plus side, it was not possible
to render at all with custom render args before, and it works now.

The gmic.py change was not tested. However, I did look at the
decode() call, and it looked like it was referencing a string.
However, I would strongly encourage testing this assumption!