### PR TITLE
Refactor ProRes render options

### DIFF
--- a/flowblade-trunk/Flowblade/res/render/renderencoding.xml
+++ b/flowblade-trunk/Flowblade/res/render/renderencoding.xml
@@ -61,6 +61,16 @@
     <qualityqroup id="variablenooption">
         <quality name="variable 1 pass"/>
     </qualityqroup>
+    <qualityqroup id="prores422" defaultindex="2">
+        <quality name="Proxy" replvalues="%PROFILE% 0" />
+        <quality name="LT" replvalues="%PROFILE% 1" />
+        <quality name="Normal" replvalues="%PROFILE% 2" />
+        <quality name="HQ" replvalues="%PROFILE% 3" />
+    </qualityqroup>
+    <qualityqroup id="prores4444" defaultindex="0">
+        <quality name="Normal" replvalues="%PROFILE% 4" />
+        <quality name="XQ" replvalues="%PROFILE% 5" />
+    </qualityqroup>
     <qualityqroup id="not_settable">
         <quality name="not settable"/>
     </qualityqroup>
@@ -94,8 +104,11 @@
     <encodingoption name="Lossless HuffYUV / .avi" extension="avi" audiodesc=" pcm"  type="av" resize="True" qgroup="lossless">
         <profile args="f=avi acodec=pcm_s24le ac=2 vcodec=huffyuv" />
     </encodingoption>
-    <encodingoption name="Apple ProRes 4:2:2 / .mov" extension="mov" audiodesc=" pcm" type="av" resize="True" qgroup="variablenooption">
-        <profile args="f=mov acodec=pcm_s24le ac=2 vcodec=prores vendor=ap10 pix_fmt=yuv422p10le vb=0 g=0 bf=0 threads=1 vprofile=2" />
+    <encodingoption name="Apple ProRes 422 / .mov" extension="mov" audiodesc=" pcm" type="av" resize="True" qgroup="prores422">
+        <profile args="f=mov acodec=pcm_s24le ac=2 vcodec=prores vprofile=%PROFILE% vendor=ap10 pix_fmt=yuv422p10le" />
+    </encodingoption>
+    <encodingoption name="Apple ProRes 4444 / .mov" extension="mov" audiodesc=" pcm" type="av" resize="True" qgroup="prores4444">
+        <profile args="f=mov acodec=pcm_s24le ac=2 vcodec=prores_ks vprofile=%PROFILE% vendor=ap10 pix_fmt=yuva444p10le" />
     </encodingoption>
 
 


### PR DESCRIPTION
Previously, we only had a single ProRes render option, which was not
configured optimally.

This commit exposes more of the underlying ffmpeg ProRes options.

The previous "Apple ProRes 4:2:2" entry was removed. Two new entries
were added: "Apple ProRes 422", and "Apple ProRes 4444". I tried to
merge them into a single "Apple ProRes" entry in renderencoding.xml,
but this didn't work because some of the options that needed to be
changed didn't play well with some assumptions in Flowblade about
the vcodec setting (each entry uses a different ffmpeg codec). I
tried to set vcodec dynamically using replvalues, but couldn't quite
get that to work.

ProRes is a family of related codecs tuned for different quality
settings, so instead of tuning qscale or VBR settings, you instead
switch to a different named ProRes codec.

The previous unused quality group pulldown menu is now replaced with
dedicated ProRes quality group menu entries representing the different
codec families.

This update also removes the "threads 1" parameter. On my six core
machine, this makes renders go 600% faster and still produces
identical files with no issues.