### PR TITLE
Add/update selected 2K/4K/8K profiles

### DIFF
--- a/flowblade-trunk/Flowblade/res/profiles/dci_2k_2398
+++ b/flowblade-trunk/Flowblade/res/profiles/dci_2k_2398
@@ -1,11 +1,11 @@
-description=4K UHD 2160p 29.97 fps
-frame_rate_num=30000
+description=DCI 2K 23.98 fps
+frame_rate_num=24000
 frame_rate_den=1001
-width=3840
-height=2160
+width=2048
+height=1080
 progressive=1
 sample_aspect_num=1
 sample_aspect_den=1
-display_aspect_num=16
+display_aspect_num=17
 display_aspect_den=9
 colorspace=2020

--- a/flowblade-trunk/Flowblade/res/profiles/dci_2k_24
+++ b/flowblade-trunk/Flowblade/res/profiles/dci_2k_24
@@ -1,11 +1,11 @@
-description=4K UHD 2160p 30 fps
-frame_rate_num=30
+description=DCI 2K 24 fps
+frame_rate_num=24
 frame_rate_den=1
-width=3840
-height=2160
+width=2048
+height=1080
 progressive=1
 sample_aspect_num=1
 sample_aspect_den=1
-display_aspect_num=16
+display_aspect_num=17
 display_aspect_den=9
 colorspace=2020

--- a/flowblade-trunk/Flowblade/res/profiles/dci_2k_25
+++ b/flowblade-trunk/Flowblade/res/profiles/dci_2k_25
@@ -1,11 +1,11 @@
-description=4K UHD 2160p 30 fps
-frame_rate_num=30
+description=DCI 2K 25 fps
+frame_rate_num=25
 frame_rate_den=1
-width=3840
-height=2160
+width=2048
+height=1080
 progressive=1
 sample_aspect_num=1
 sample_aspect_den=1
-display_aspect_num=16
+display_aspect_num=17
 display_aspect_den=9
 colorspace=2020

--- a/flowblade-trunk/Flowblade/res/profiles/dci_2k_2997
+++ b/flowblade-trunk/Flowblade/res/profiles/dci_2k_2997
@@ -1,11 +1,11 @@
-description=4K UHD 2160p 29.97 fps
+description=DCI 2K 29.97 fps
 frame_rate_num=30000
 frame_rate_den=1001
-width=3840
-height=2160
+width=2048
+height=1080
 progressive=1
 sample_aspect_num=1
 sample_aspect_den=1
-display_aspect_num=16
+display_aspect_num=17
 display_aspect_den=9
 colorspace=2020

--- a/flowblade-trunk/Flowblade/res/profiles/dci_2k_50
+++ b/flowblade-trunk/Flowblade/res/profiles/dci_2k_50
@@ -1,11 +1,11 @@
-description=4K UHD 2160p 30 fps
-frame_rate_num=30
+description=DCI 2K 50 fps
+frame_rate_num=50
 frame_rate_den=1
-width=3840
-height=2160
+width=2048
+height=1080
 progressive=1
 sample_aspect_num=1
 sample_aspect_den=1
-display_aspect_num=16
+display_aspect_num=17
 display_aspect_den=9
 colorspace=2020

--- a/flowblade-trunk/Flowblade/res/profiles/dci_2k_5994
+++ b/flowblade-trunk/Flowblade/res/profiles/dci_2k_5994
@@ -1,11 +1,11 @@
-description=4K UHD 2160p 29.97 fps
-frame_rate_num=30000
+description=DCI 2K 59.94 fps
+frame_rate_num=60000
 frame_rate_den=1001
-width=3840
-height=2160
+width=2048
+height=1080
 progressive=1
 sample_aspect_num=1
 sample_aspect_den=1
-display_aspect_num=16
+display_aspect_num=17
 display_aspect_den=9
 colorspace=2020

--- a/flowblade-trunk/Flowblade/res/profiles/dci_4k_2398
+++ b/flowblade-trunk/Flowblade/res/profiles/dci_4k_2398
@@ -1,11 +1,11 @@
-description=4K UHD 2160p 30 fps
-frame_rate_num=30
-frame_rate_den=1
-width=3840
+description=DCI 4K 23.98 fps
+frame_rate_num=24000
+frame_rate_den=1001
+width=4096
 height=2160
 progressive=1
 sample_aspect_num=1
 sample_aspect_den=1
-display_aspect_num=16
+display_aspect_num=17
 display_aspect_den=9
 colorspace=2020

--- a/flowblade-trunk/Flowblade/res/profiles/dci_4k_24
+++ b/flowblade-trunk/Flowblade/res/profiles/dci_4k_24
@@ -1,11 +1,11 @@
-description=4K UHD 2160p 30 fps
-frame_rate_num=30
+description=DCI 4K 24 fps
+frame_rate_num=24
 frame_rate_den=1
-width=3840
+width=4096
 height=2160
 progressive=1
 sample_aspect_num=1
 sample_aspect_den=1
-display_aspect_num=16
+display_aspect_num=17
 display_aspect_den=9
 colorspace=2020

--- a/flowblade-trunk/Flowblade/res/profiles/dci_4k_25
+++ b/flowblade-trunk/Flowblade/res/profiles/dci_4k_25
@@ -1,11 +1,11 @@
-description=4K UHD 2160p 30 fps
-frame_rate_num=30
+description=DCI 4K 25 fps
+frame_rate_num=25
 frame_rate_den=1
-width=3840
+width=4096
 height=2160
 progressive=1
 sample_aspect_num=1
 sample_aspect_den=1
-display_aspect_num=16
+display_aspect_num=17
 display_aspect_den=9
 colorspace=2020

--- a/flowblade-trunk/Flowblade/res/profiles/dci_4k_2997
+++ b/flowblade-trunk/Flowblade/res/profiles/dci_4k_2997
@@ -1,11 +1,11 @@
-description=4K UHD 2160p 30 fps
-frame_rate_num=30
-frame_rate_den=1
-width=3840
+description=DCI 4K 29.97 fps
+frame_rate_num=30000
+frame_rate_den=1001
+width=4096
 height=2160
 progressive=1
 sample_aspect_num=1
 sample_aspect_den=1
-display_aspect_num=16
+display_aspect_num=17
 display_aspect_den=9
 colorspace=2020

--- a/flowblade-trunk/Flowblade/res/profiles/dci_4k_50
+++ b/flowblade-trunk/Flowblade/res/profiles/dci_4k_50
@@ -1,11 +1,11 @@
-description=4K UHD 2160p 30 fps
-frame_rate_num=30
+description=DCI 4K 50 fps
+frame_rate_num=50
 frame_rate_den=1
-width=3840
+width=4096
 height=2160
 progressive=1
 sample_aspect_num=1
 sample_aspect_den=1
-display_aspect_num=16
+display_aspect_num=17
 display_aspect_den=9
 colorspace=2020

--- a/flowblade-trunk/Flowblade/res/profiles/dci_4k_5994
+++ b/flowblade-trunk/Flowblade/res/profiles/dci_4k_5994
@@ -1,11 +1,11 @@
-description=4K UHD 2160p 30 fps
-frame_rate_num=30
-frame_rate_den=1
-width=3840
+description=DCI 4K 59.94 fps
+frame_rate_num=60000
+frame_rate_den=1001
+width=4096
 height=2160
 progressive=1
 sample_aspect_num=1
 sample_aspect_den=1
-display_aspect_num=16
+display_aspect_num=17
 display_aspect_den=9
 colorspace=2020

--- a/flowblade-trunk/Flowblade/res/profiles/uhd_2160p_2398
+++ b/flowblade-trunk/Flowblade/res/profiles/uhd_2160p_2398
@@ -8,4 +8,4 @@ sample_aspect_num=1
 sample_aspect_den=1
 display_aspect_num=16
 display_aspect_den=9
-colorspace=709
+colorspace=2020

--- a/flowblade-trunk/Flowblade/res/profiles/uhd_2160p_24
+++ b/flowblade-trunk/Flowblade/res/profiles/uhd_2160p_24
@@ -8,4 +8,4 @@ sample_aspect_num=1
 sample_aspect_den=1
 display_aspect_num=16
 display_aspect_den=9
-colorspace=709
+colorspace=2020

--- a/flowblade-trunk/Flowblade/res/profiles/uhd_2160p_25
+++ b/flowblade-trunk/Flowblade/res/profiles/uhd_2160p_25
@@ -8,4 +8,4 @@ sample_aspect_num=1
 sample_aspect_den=1
 display_aspect_num=16
 display_aspect_den=9
-colorspace=709
+colorspace=2020

--- a/flowblade-trunk/Flowblade/res/profiles/uhd_2160p_50
+++ b/flowblade-trunk/Flowblade/res/profiles/uhd_2160p_50
@@ -8,4 +8,4 @@ sample_aspect_num=1
 sample_aspect_den=1
 display_aspect_num=16
 display_aspect_den=9
-colorspace=709
+colorspace=2020

--- a/flowblade-trunk/Flowblade/res/profiles/uhd_2160p_5994
+++ b/flowblade-trunk/Flowblade/res/profiles/uhd_2160p_5994
@@ -8,4 +8,4 @@ sample_aspect_num=1
 sample_aspect_den=1
 display_aspect_num=16
 display_aspect_den=9
-colorspace=709
+colorspace=2020

--- a/flowblade-trunk/Flowblade/res/profiles/uhd_2160p_60
+++ b/flowblade-trunk/Flowblade/res/profiles/uhd_2160p_60
@@ -8,4 +8,4 @@ sample_aspect_num=1
 sample_aspect_den=1
 display_aspect_num=16
 display_aspect_den=9
-colorspace=709
+colorspace=2020

--- a/flowblade-trunk/Flowblade/res/profiles/uhd_4320p_2398
+++ b/flowblade-trunk/Flowblade/res/profiles/uhd_4320p_2398
@@ -1,8 +1,8 @@
-description=4K UHD 2160p 30 fps
-frame_rate_num=30
-frame_rate_den=1
-width=3840
-height=2160
+description=8K UHD 4320p 23.98 fps
+frame_rate_num=24000
+frame_rate_den=1001
+width=7680
+height=4320
 progressive=1
 sample_aspect_num=1
 sample_aspect_den=1

--- a/flowblade-trunk/Flowblade/res/profiles/uhd_4320p_24
+++ b/flowblade-trunk/Flowblade/res/profiles/uhd_4320p_24
@@ -1,8 +1,8 @@
-description=4K UHD 2160p 30 fps
-frame_rate_num=30
+description=8K UHD 4320p 24 fps
+frame_rate_num=24
 frame_rate_den=1
-width=3840
-height=2160
+width=7680
+height=4320
 progressive=1
 sample_aspect_num=1
 sample_aspect_den=1

--- a/flowblade-trunk/Flowblade/res/profiles/uhd_4320p_25
+++ b/flowblade-trunk/Flowblade/res/profiles/uhd_4320p_25
@@ -1,8 +1,8 @@
-description=4K UHD 2160p 30 fps
-frame_rate_num=30
+description=8K UHD 4320p 25 fps
+frame_rate_num=25
 frame_rate_den=1
-width=3840
-height=2160
+width=7680
+height=4320
 progressive=1
 sample_aspect_num=1
 sample_aspect_den=1

--- a/flowblade-trunk/Flowblade/res/profiles/uhd_4320p_2997
+++ b/flowblade-trunk/Flowblade/res/profiles/uhd_4320p_2997
@@ -1,8 +1,8 @@
-description=4K UHD 2160p 30 fps
-frame_rate_num=30
-frame_rate_den=1
-width=3840
-height=2160
+description=8K UHD 4320p 29.97 fps
+frame_rate_num=30000
+frame_rate_den=1001
+width=7680
+height=4320
 progressive=1
 sample_aspect_num=1
 sample_aspect_den=1

--- a/flowblade-trunk/Flowblade/res/profiles/uhd_4320p_30
+++ b/flowblade-trunk/Flowblade/res/profiles/uhd_4320p_30
@@ -1,8 +1,8 @@
-description=4K UHD 2160p 30 fps
+description=8K UHD 4320p 30 fps
 frame_rate_num=30
 frame_rate_den=1
-width=3840
-height=2160
+width=7680
+height=4320
 progressive=1
 sample_aspect_num=1
 sample_aspect_den=1

--- a/flowblade-trunk/Flowblade/res/profiles/uhd_4320p_50
+++ b/flowblade-trunk/Flowblade/res/profiles/uhd_4320p_50
@@ -1,8 +1,8 @@
-description=4K UHD 2160p 30 fps
-frame_rate_num=30
+description=8K UHD 4320p 50 fps
+frame_rate_num=50
 frame_rate_den=1
-width=3840
-height=2160
+width=7680
+height=4320
 progressive=1
 sample_aspect_num=1
 sample_aspect_den=1

--- a/flowblade-trunk/Flowblade/res/profiles/uhd_4320p_5994
+++ b/flowblade-trunk/Flowblade/res/profiles/uhd_4320p_5994
@@ -1,8 +1,8 @@
-description=4K UHD 2160p 30 fps
-frame_rate_num=30
-frame_rate_den=1
-width=3840
-height=2160
+description=8K UHD 4320p 59.94 fps
+frame_rate_num=60000
+frame_rate_den=1001
+width=7680
+height=4320
 progressive=1
 sample_aspect_num=1
 sample_aspect_den=1

--- a/flowblade-trunk/Flowblade/res/profiles/uhd_4320p_60
+++ b/flowblade-trunk/Flowblade/res/profiles/uhd_4320p_60
@@ -1,8 +1,8 @@
-description=4K UHD 2160p 30 fps
-frame_rate_num=30
+description=8K UHD 4320p 60 fps
+frame_rate_num=60
 frame_rate_den=1
-width=3840
-height=2160
+width=7680
+height=4320
 progressive=1
 sample_aspect_num=1
 sample_aspect_den=1


### PR DESCRIPTION
This commit adds a number of project profile settings, and changes
some existing profile settings.

DCI 2K and DCI 4K profiles are added, in a variety of frame rates.
The Digital Cinema Initiative defines a maximum 2K and 4K resolution
of 2048x1080 and 4096x2160, respectively. These profiles don't
completely adhere to the DCI spec (due to colorspace and frame rate
differences). However, the Fujifilm X-T3 and Atmos Ninja recorders
support these settings, and Fujifilm is calling their 4096x2160
resolution setting DCI. Technically the 24 fps DCI settings are the
closest to actually being compliant, but real DCI requires the P3
color space, 12 bits per channel, etc. Never the less, now you can
take footage from a Fujifilm mirrorless camera in these resolutions,
drop it into a new Flowblade project, and it will offer to change
the project to one of these resolutions instead of crashing.

This commit also adds 8K UHD profile support to mirror the existing
4K UHD profiles. I don't personally have an 8K camera, and am not
sure if anyone _really_ needs one, but more is better, and these
things are showing up on the market.

Finally, since the DCI and 8K profiles were configured to use the
Rec. 2020 color space, and since Rec. 709 technically only applies
to 1080 and 720 projects, I changed the UHD 4K profiles to use
the Rec. 2020 color space as well. It looks like MLT supports it
anyway.