### PR TITLE
Round fractional fps in Change Project Profile dialog

### DIFF
--- a/flowblade-trunk/Flowblade/guicomponents.py
+++ b/flowblade-trunk/Flowblade/guicomponents.py
@@ -2217,6 +2217,13 @@ def set_profile_info_labels_text(label, show_description):
 
 def set_profile_info_values_text(profile, label, show_description):
     str_list = []
+
+    # round fractional frame rates to something easier to read
+    fps = profile.fps()
+    display_fps = str(round(fps))
+    if 0 != (fps % 1):
+        display_fps = str(round((float(fps)), 2))
+
     if show_description:
         str_list.append(profile.description())
         str_list.append("\n")
@@ -2224,7 +2231,7 @@ def set_profile_info_values_text(profile, label, show_description):
     str_list.append(":")
     str_list.append(str(profile.display_aspect_den()))
     str_list.append("\n")
-    str_list.append(str(profile.fps()))
+    str_list.append(display_fps)
     str_list.append("\n")
     str_list.append(str(profile.width()))
     str_list.append(" x ")


### PR DESCRIPTION
Previously, if you went to the Change Project Profile dialog and
selected a project profile with fractional frame rates, it would
show you as many decimal points as Python could calculate
(e.g. 23.976023976023978).

This commit adds some code that selectively rounds frame rates in
the Change Project Profile dialog to two decimal points, but leaves
non-fractional frame rates as whole integers without any decimal
points. Basically, the integer frame rates look the same as always,
but the NTSC frame rates look more like what you would expect.