### PR TITLE
Fix GMIC token parsing

### DIFF
--- a/flowblade-trunk/Flowblade/tools/gmic.py
+++ b/flowblade-trunk/Flowblade/tools/gmic.py
@@ -115,6 +115,7 @@ def get_gmic_version():
     tokens = output.split()
     clended = []
     for token in tokens:
+        token = token.decode("utf-8")
         str1 = token.replace('.','')
         str2 = str1.replace(',','')
         if str2.isdigit(): # this is based on assumtion that str2 ends up being number like "175" or 215" etc. only for version number token


### PR DESCRIPTION
An earlier commit removed a token.decode("utf-8") call on what
looked like a string (which would have been a bug in Python 3).
However, it was correct the first time.

This commit reverts the earlier change, which allows the GMIC
section of the program to launch.