### PR TITLE
Save project using atomicfile (in Python 3)

### DIFF
--- a/flowblade-trunk/Flowblade/atomicfile.py
+++ b/flowblade-trunk/Flowblade/atomicfile.py
@@ -105,7 +105,7 @@ class AtomicFileWriter(object):
 
                 # if we didn't get an OSError by now, turn the numeric
                 # file descriptor into a Python file object
-                self.file_obj = os.fdopen(fd, "w")
+                self.file_obj = os.fdopen(fd, self.mode)
 
                 # remember the temp file path
                 self.tmp_file_path = maybe_tmp_file_path

--- a/flowblade-trunk/Flowblade/persistance.py
+++ b/flowblade-trunk/Flowblade/persistance.py
@@ -195,16 +195,9 @@ def save_project(project, file_path, changed_profile_desc=None):
     remove_attrs(s_proj, PROJECT_REMOVE)
 
     # Write out file.
-    outfile = open(file_path,'wb')
-    pickle.dump(s_proj, outfile)
-    
-    """
-    with atomicfile.AtomicFileWriter(file_path, "w") as afw:
-        write_file = afw.get_file()
-        pickle_str =  pickle.dumps(s_proj)
-        print (pickle_str)
-        pickle.dump(pickle_str, write_file)
-    """
+    with atomicfile.AtomicFileWriter(file_path, "wb") as afw:
+        outfile = afw.get_file()
+        pickle.dump(s_proj, outfile)
 
 def get_p_sequence(sequence):
     """


### PR DESCRIPTION
The Flowblade project file uses the Python pickle format.

In Python 3, strings and bytes must be kept separate.

The pickle format is binary.

When writing a pickle file, you must open the filehandle with the
"wb" mode (write binary).

AtomicFileWriter was previously only using "w" mode, even when "wb"
was specified.

Now, AtomicFileWriter respects the file write mode setting when
opening files. As a result, saving project files can be done
atomically again, and once again uses atomicfile as a wrapper
around the file writes to avoid the possibility of the project
file being corrupted if the save doesn't complete.