### PR TITLE
Use atomicfile in most places files are written

### DIFF
--- a/flowblade-trunk/Flowblade/audiowaveform.py
+++ b/flowblade-trunk/Flowblade/audiowaveform.py
@@ -31,6 +31,7 @@ import time
 from gi.repository import Gtk, Gdk
 
 import appconsts
+import atomicfile
 import dialogutils
 from editorstate import PROJECT
 import gui
@@ -148,8 +149,9 @@ class WaveformCreator(threading.Thread):
 
         if not self.abort:
             self.clip.waveform_data = frame_levels
-            write_file = open(self.file_cache_path, "wb")
-            pickle.dump(frame_levels, write_file)
+            with atomicfile.AtomicFileWriter(self.file_cache_path, "wb") as afw:
+                write_file = afw.get_file()
+                pickle.dump(frame_levels, write_file)
 
             Gdk.threads_enter()
             self.dialog.progress_bar.set_fraction(1.0)

--- a/flowblade-trunk/Flowblade/audiowaveformrenderer.py
+++ b/flowblade-trunk/Flowblade/audiowaveformrenderer.py
@@ -35,6 +35,7 @@ gi.require_version('Gdk', '3.0')
 from gi.repository import Gdk
 
 import appconsts
+import atomicfile
 import editorpersistance
 import editorstate
 import mltenv
@@ -224,8 +225,9 @@ class WaveformCreator(threading.Thread):
             frame_levels[frame] = float(val)
             self.last_rendered_frame = frame
 
-        write_file = open(self.file_cache_path, "wb")
-        pickle.dump(frame_levels, write_file)
+        with atomicfile.AtomicFileWriter(self.file_cache_path, "wb") as afw:
+            write_file = afw.get_file()
+            pickle.dump(frame_levels, write_file)
 
     def _get_temp_producer(self, clip_path, profile):
         temp_producer = mlt.Producer(profile, str(clip_path))

--- a/flowblade-trunk/Flowblade/editorpersistance.py
+++ b/flowblade-trunk/Flowblade/editorpersistance.py
@@ -37,6 +37,7 @@ import os
 import pickle
 
 import appconsts
+import atomicfile
 import mltprofiles
 import userfolders
 import utils
@@ -64,14 +65,15 @@ def load():
     recents_file_path = userfolders.get_config_dir() + RECENT_DOC
 
     global prefs, recent_projects
-        
+
     try:
         f = open(prefs_file_path, "rb")
         prefs = pickle.load(f)
     except:
         prefs = EditorPreferences()
-        write_file = open(prefs_file_path, "wb")
-        pickle.dump(prefs, write_file)
+        with atomicfile.AtomicFileWriter(prefs_file_path, "wb") as afw:
+            write_file = afw.get_file()
+            pickle.dump(prefs, write_file)
 
     # Override deprecated preferences to default values.
     prefs.delta_overlay = True
@@ -86,8 +88,9 @@ def load():
     except:
         recent_projects = utils.EmptyClass()
         recent_projects.projects = []
-        write_file = open(recents_file_path, "wb")
-        pickle.dump(recent_projects, write_file)
+        with atomicfile.AtomicFileWriter(recents_file_path, "wb") as afw:
+            write_file = afw.get_file()
+            pickle.dump(recent_projects, write_file)
 
     # Remove non-existing projects from recents list
     remove_list = []
@@ -98,8 +101,9 @@ def load():
     if len(remove_list) > 0:
         for proj_path in remove_list:
             recent_projects.projects.remove(proj_path)
-        write_file = open(recents_file_path, "wb")
-        pickle.dump(recent_projects, write_file)
+        with atomicfile.AtomicFileWriter(recents_file_path, "wb") as afw:
+            write_file = afw.get_file()
+            pickle.dump(recent_projects, write_file)
         
     # Versions of program may have different prefs objects and 
     # we may need to to update prefs on disk if user has e.g.
@@ -109,8 +113,9 @@ def load():
     if len(prefs.__dict__) != len(current_prefs.__dict__):
         current_prefs.__dict__.update(prefs.__dict__)
         prefs = current_prefs
-        write_file = open(prefs_file_path, "wb")
-        pickle.dump(prefs, write_file)
+        with atomicfile.AtomicFileWriter(prefs_file_path, "wb") as afw:
+            write_file = afw.get_file()
+            pickle.dump(prefs, write_file)
         print("prefs updated to new version, new param count:", len(prefs.__dict__))
 
 def save():
@@ -120,11 +125,13 @@ def save():
     prefs_file_path = userfolders.get_config_dir()+ PREFS_DOC
     recents_file_path = userfolders.get_config_dir() + RECENT_DOC
     
-    write_file = open(prefs_file_path, "wb")
-    pickle.dump(prefs, write_file)
+    with atomicfile.AtomicFileWriter(prefs_file_path, "wb") as afw:
+        write_file = afw.get_file()
+        pickle.dump(prefs, write_file)
 
-    write_file = open(recents_file_path, "wb")
-    pickle.dump(recent_projects, write_file)
+    with atomicfile.AtomicFileWriter(recents_file_path, "wb") as afw:
+        write_file = afw.get_file()
+        pickle.dump(recent_projects, write_file)
 
 def add_recent_project_path(path):
     """
@@ -159,8 +166,9 @@ def remove_non_existing_recent_projects():
     if len(remove_list) > 0:
         for proj_path in remove_list:
             recent_projects.projects.remove(proj_path)
-        write_file = open(recents_file_path, "wb")
-        pickle.dump(recent_projects, write_file)
+        with atomicfile.AtomicFileWriter(recents_file_path, "wb") as afw:
+            write_file = afw.get_file()
+            pickle.dump(recent_projects, write_file)
         
 def fill_recents_menu_widget(menu_item, callback):
     """

--- a/flowblade-trunk/Flowblade/exporting.py
+++ b/flowblade-trunk/Flowblade/exporting.py
@@ -31,6 +31,7 @@ import re
 import shutil
 
 import appconsts
+import atomicfile
 import dialogs
 import dialogutils
 from editorstate import PLAYER
@@ -98,9 +99,9 @@ def _edl_xml_render_done(data):
     edl_path  = data
     mlt_parse = MLTXMLToEDLParse(get_edl_temp_xml_path(), current_sequence())
     edl_contents = mlt_parse.create_edl()
-    f = open(edl_path, 'w')
-    f.write(edl_contents)
-    f.close()
+    with atomicfile.AtomicFileWriter(edl_path, "w") as afw:
+        f = afw.get_file()
+        f.write(edl_contents)
 
 def get_edl_temp_xml_path():
     return userfolders.get_cache_dir() + "edl_temp_xml.xml"

--- a/flowblade-trunk/Flowblade/gui.py
+++ b/flowblade-trunk/Flowblade/gui.py
@@ -27,6 +27,7 @@ from gi.repository import Gtk, Gdk
 import pickle
 
 import appconsts
+import atomicfile
 import editorpersistance
 import respaths
 import userfolders
@@ -219,8 +220,9 @@ def save_current_colors():
     # Used to communicate theme colors to tools like gmic.py running on separate process
     colors = (unpack_gdk_color(_selected_bg_color), unpack_gdk_color(_bg_color), unpack_gdk_color(_button_colors))
     save_file_path = _colors_data_path()
-    write_file = open(save_file_path, "wb")
-    pickle.dump(colors, write_file)
+    with atomicfile.AtomicFileWriter(save_file_path, "wb") as afw:
+        write_file = afw.get_file()
+        pickle.dump(colors, write_file)
 
 def load_current_colors():
     load_path = _colors_data_path()

--- a/flowblade-trunk/Flowblade/profilesmanager.py
+++ b/flowblade-trunk/Flowblade/profilesmanager.py
@@ -27,6 +27,7 @@ from gi.repository import Gtk
 
 import os
 
+import atomicfile
 import dialogutils
 import editorpersistance
 import gui
@@ -259,9 +260,9 @@ def _save_profile_clicked(widgets, user_profiles_view):
                                 _("Delete profile and save again."),  gui.editor_window.window)
         return
 
-    profile_file = open(profile_path, "w")
-    profile_file.write(file_contents)
-    profile_file.close()
+    with atomicfile.AtomicFileWriter(profile_path, "w") as afw:
+        profile_file = afw.get_file()
+        profile_file.write(file_contents)
 
     dialogutils.info_message(_("Profile '") +  description.get_text() + _("' saved."), \
                  _("You can now create a new project using the new profile."), gui.editor_window.window)

--- a/flowblade-trunk/Flowblade/projectmediaimport.py
+++ b/flowblade-trunk/Flowblade/projectmediaimport.py
@@ -32,6 +32,7 @@ from gi.repository import Gtk, Gdk
 from gi.repository import GLib
 
 import appconsts
+import atomicfile
 import editorstate
 import editorpersistance
 import gui
@@ -82,10 +83,10 @@ class ProjectLoadThread(threading.Thread):
                 continue
             if os.path.isfile(media_file.path):                
                 media_assets = media_assets + str(media_file.path) + "\n"
-        
-        f = open(_get_assets_file(), 'w')
-        f.write(media_assets)
-        f.close()
+
+        with atomicfile.AtomicFileWriter(_get_assets_file(), "w") as afw:
+            f = afw.get_file()
+            f.write(media_assets)
 
         _shutdown()
 

--- a/flowblade-trunk/Flowblade/proxyediting.py
+++ b/flowblade-trunk/Flowblade/proxyediting.py
@@ -30,6 +30,7 @@ from gi.repository import Gtk, Gdk
 
 import app
 import appconsts
+import atomicfile
 import dialogs
 import dialogutils
 import editorpersistance
@@ -648,10 +649,10 @@ def _get_proxy_profile(project):
     file_contents += "display_aspect_den=" + str(project_profile.display_aspect_den()) + "\n"
 
     proxy_profile_path = userfolders.get_cache_dir() + "temp_proxy_profile"
-    profile_file = open(proxy_profile_path, "w")
-    profile_file.write(file_contents)
-    profile_file.close()
-    
+    with atomicfile.AtomicFileWriter(proxy_profile_path, "w") as afw:
+        profile_file = afw.get_file()
+        profile_file.write(file_contents)
+
     proxy_profile = mlt.Profile(proxy_profile_path)
     return proxy_profile
 

--- a/flowblade-trunk/Flowblade/render.py
+++ b/flowblade-trunk/Flowblade/render.py
@@ -34,6 +34,7 @@ import os
 import time
 import threading
 
+import atomicfile
 import dialogutils
 import editorstate
 from editorstate import current_sequence
@@ -374,11 +375,11 @@ def _save_opts_pressed():
 def _save_opts_dialog_callback(dialog, response_id):
     if response_id == Gtk.ResponseType.ACCEPT:
         file_path = dialog.get_filenames()[0]
-        opts_file = open(file_path, "w")
         buf = widgets.args_panel.opts_view.get_buffer()
         opts_text = buf.get_text(buf.get_start_iter(), buf.get_end_iter(), include_hidden_chars=True)
-        opts_file.write(opts_text)
-        opts_file.close()
+        with atomicfile.AtomicFileWriter(file_path, "w") as afw:
+            opts_file = afw.get_file()
+            opts_file.write(opts_text)
         dialog.destroy()
     else:
         dialog.destroy()

--- a/flowblade-trunk/Flowblade/tools/batchrendering.py
+++ b/flowblade-trunk/Flowblade/tools/batchrendering.py
@@ -45,6 +45,7 @@ import time
 import threading
 import unicodedata
 
+import atomicfile
 import appconsts
 import dialogutils
 import editorstate
@@ -543,12 +544,14 @@ class BatchRenderItemData:
 
     def save(self):
         item_path = get_datafiles_dir() + self.generate_identifier() + ".renderitem"
-        item_write_file = open(item_path, "wb")
-        pickle.dump(self, item_write_file)
+        with atomicfile.AtomicFileWriter(item_path, "wb") as afw:
+            item_write_file = afw.get_file()
+            pickle.dump(self, item_write_file)
 
     def save_as_single_render_item(self, item_path):
-        item_write_file = open(item_path, "wb")
-        pickle.dump(self, item_write_file)
+        with atomicfile.AtomicFileWriter(item_path, "wb") as afw:
+            item_write_file = afw.get_file()
+            pickle.dump(self, item_write_file)
 
     def delete_from_queue(self):
         identifier = self.generate_identifier()

--- a/flowblade-trunk/Flowblade/tools/exportardour.py
+++ b/flowblade-trunk/Flowblade/tools/exportardour.py
@@ -1777,7 +1777,7 @@ def _create_ardour_project_file(basedir, project):
     s.append(_get_ardour_extra())
 
     # write the ardour project file
-    with atomicfile.AtomicFileWriter(ardour_project_file_path, "wb") as afw:
+    with atomicfile.AtomicFileWriter(ardour_project_file_path, "w") as afw:
         # get a reference to the temp file we're writing
         f = afw.get_file()
 

--- a/flowblade-trunk/Flowblade/tools/gmic.py
+++ b/flowblade-trunk/Flowblade/tools/gmic.py
@@ -39,6 +39,7 @@ import time
 import webbrowser
 
 import appconsts
+import atomicfile
 import cairoarea
 import dialogutils
 import editorstate
@@ -410,11 +411,11 @@ def save_script_dialog(callback):
 def _save_script_dialog_callback(dialog, response_id):
     if response_id == Gtk.ResponseType.ACCEPT:
         file_path = dialog.get_filenames()[0]
-        script_file = open(file_path, "w")
         buf = _window.script_view.get_buffer()
         script_text = buf.get_text(buf.get_start_iter(), buf.get_end_iter(), include_hidden_chars=True)
-        script_file.write(script_text)
-        script_file.close()
+        with atomicfile.AtomicFileWriter(file_path, "w") as afw:
+            script_file = afw.get_file()
+            script_file.write(script_text)
         dialog.destroy()
     else:
         dialog.destroy()

--- a/flowblade-trunk/Flowblade/tools/titler.py
+++ b/flowblade-trunk/Flowblade/tools/titler.py
@@ -30,6 +30,7 @@ from gi.repository import GLib, GObject
 from gi.repository import Pango
 from gi.repository import PangoCairo
 
+import atomicfile
 import toolsdialogs
 from editorstate import PLAYER
 import editorstate
@@ -175,8 +176,9 @@ class TitlerData:
         save_data = copy.copy(self)
         for layer in save_data.layers:
             layer.pango_layout = None
-        write_file = open(save_file_path, 'wb')
-        pickle.dump(save_data, write_file)
+        with atomicfile.AtomicFileWriter(save_file_path, "wb") as afw:
+            write_file = afw.get_file()
+            pickle.dump(save_data, write_file)
         self.create_pango_layouts() # we just destroyed these because they don't pickle, they need to be recreated.
 
     def create_pango_layouts(self):


### PR DESCRIPTION
I went through the codebase and found all of the places where files
were written using the open() call, and checked each of them to
see if they could be converted to use atomicfile instead.

Some of the calls to open() were doing things that didn't seem
appropriate for atomicfile to handle. Things like writing log files
that might be watched in realtime. Anything involving Popen, FLOG,
stdout, stderr, or dup2().

Additionally, there are other instances where files are written
directly by other programs like ffmpeg. These were not addressed
either.

After that, there were a dozen or so calls that were mostly writing
project files, prefs files, EDLs, and things like that, where the
pattern was to write a file all in one shot. All of these instances
were converted from using open()/close() to using atomicfile instead.

Finally, a regression in the Ardour export code was fixed. It was
using the "wb" mode, and was fixed to use the "w" write mode since
the Ardour session file is XML.