### PR TITLE
text revision

### DIFF
--- a/flowblade-trunk/Flowblade/res/help/en/advanced.html
+++ b/flowblade-trunk/Flowblade/res/help/en/advanced.html
@@ -30,7 +30,7 @@ It is possible to import full contents of another Sequence into Sequence current
 </p>
 
 <ol>
-<li> Select <b>Project->Sequence->Import Another Sequence into this Sequnce...</b></li>
+<li> Select <b>Sequence->Import Another Sequence into this Sequnce...</b></li>
 <li> Select Import action.</li>
 <ul>
 <li> <b>Append Sequence</b> adds imported Sequence at the end of current Sequence</li>
@@ -46,7 +46,7 @@ It is possible to import full contents of another Sequence into Sequence current
 <h3>Split part of Sequence to new Sequence</h3>
 
 <ol>
-<li> Select <b>Project->Sequence->Split to new Sequence at Playhead position</b></li>
+<li> Select <b>Sequence->Split to new Sequence at Playhead position</b></li>
 <li> After confirmation dialog the a new Sequence with contents of source Sequence after playhead position will be created and made active.</li>
 </ol>
 
@@ -205,7 +205,6 @@ In Flowblade Movie Editor you can <b>set a clip's positions to follow another cl
 
 <h3>Resyncing Sync Child Clips</h3>
 <ul>
-<li> Select <b>Edit -> Resync All to resync</b> from application menu all Sync Child Clips.</li>
 <li> Select <b>Edit - >Resync Selected to resync</b> from application menu selected Sync Child Clips.</li>
 <li> Click <b>Right Mouse</b> on Sync Child Clip and select <b>Resync</b> from popoup menu to resync single clip.</li>
 <li> Press <b>Resync Selected</b> Bbtton to resync selected Sync Child Clips.</li>


### PR DESCRIPTION
"Project-> Sequence" The word Project has been deleted because the Sequence has been taken out of the menu.
Line "Select Edit -> Resync All to resync from application menu all Sync Child Clips." has been removed because this feature is missing from the interface.