### PR TITLE
Ignore missing @2 images

### DIFF
--- a/flowblade-trunk/Flowblade/guiutils.py
+++ b/flowblade-trunk/Flowblade/guiutils.py
@@ -157,12 +157,18 @@ def get_image(img_name, suffix = ".png", force = None):
 
 # Aug-2019 - SvdB - BB
 def get_cairo_image(img_name, suffix = ".png", force = None):
+    # Apr-2020 - SvdB - Make it sturdier in case a @2 image is missing. Just display the original image.
     # Use parameter force as True or False to force the track height no matter what the preferences setting
     if force == None:
         force = editorpersistance.prefs.double_track_hights
     if force:
-        img_name = img_name + "@2"
-    return cairo.ImageSurface.create_from_png(respaths.IMAGE_PATH + img_name + suffix)
+        dbl_name = img_name + "@2"
+    try:
+        img = cairo.ImageSurface.create_from_png(respaths.IMAGE_PATH + dbl_name + suffix)
+    except:
+        print("Double height icon not found: ", img_name)
+        img = cairo.ImageSurface.create_from_png(respaths.IMAGE_PATH + img_name + suffix)
+    return img
 
 # Aug-2019 - SvdB - BB
 def get_image_button(img_file_name, width, height):

--- a/flowblade-trunk/Flowblade/guiutils.py
+++ b/flowblade-trunk/Flowblade/guiutils.py
@@ -152,8 +152,15 @@ def get_image(img_name, suffix = ".png", force = None):
     if force == None:
         force = editorpersistance.prefs.double_track_hights
     if force:
-        img_name = img_name + "@2"
-    return Gtk.Image.new_from_file(respaths.IMAGE_PATH + img_name + suffix)
+        new_name = img_name + "@2"
+    else:
+        new_name = img_name
+    try:
+        img = Gtk.Image.new_from_file(respaths.IMAGE_PATH + new_name + suffix)
+    except:
+        img = Gtk.Image.new_from_file(respaths.IMAGE_PATH + img_name + suffix)
+    return img
+    
 
 # Aug-2019 - SvdB - BB
 def get_cairo_image(img_name, suffix = ".png", force = None):
@@ -162,11 +169,12 @@ def get_cairo_image(img_name, suffix = ".png", force = None):
     if force == None:
         force = editorpersistance.prefs.double_track_hights
     if force:
-        dbl_name = img_name + "@2"
+        new_name = img_name + "@2"
+    else:
+        new_name = img_name
     try:
-        img = cairo.ImageSurface.create_from_png(respaths.IMAGE_PATH + dbl_name + suffix)
+        img = cairo.ImageSurface.create_from_png(respaths.IMAGE_PATH + new_name + suffix)
     except:
-        print("Double height icon not found: ", img_name)
         img = cairo.ImageSurface.create_from_png(respaths.IMAGE_PATH + img_name + suffix)
     return img
 


### PR DESCRIPTION
Added code so Flowblade no longer crashes if @2 images are missing.
Instead it will load the original image.