### PR TITLE
fix appdata date format

### DIFF
--- a/flowblade-trunk/installdata/io.github.jliljebl.Flowblade.appdata.xml
+++ b/flowblade-trunk/installdata/io.github.jliljebl.Flowblade.appdata.xml
@@ -21,7 +21,7 @@
   </screenshots>
   <content_rating type="oars-1.1" />
   <releases>
-    <release version="2.6" date="2020-27-06"/>
+    <release version="2.6" date="2020-06-27"/>
     <release version="2.4" date="2019-12-12"/>
     <release version="2.2" date="2019-08-24"/>
     <release version="2.0" date="2019-02-3"/>


### PR DESCRIPTION
This fixes the 2.6 build on Flathub.

https://flathub.org/builds/#/builders/10/builds/2721
```
flatpak run org.freedesktop.appstream-glib validate builddir/*/share/appdata/io.github.jliljebl.Flowblade.appdata.xml
 in dir /srv/buildbot/worker/build-x86_64-6/build (timeout 1200 secs)
 watching logfiles {}
 argv: b'flatpak run org.freedesktop.appstream-glib validate builddir/*/share/appdata/io.github.jliljebl.Flowblade.appdata.xml'
 using PTY: False
builddir/files/share/appdata/io.github.jliljebl.Flowblade.appdata.xml: FAILED:
• attribute-missing     : <release> has no timestamp
Validation of files failed
program finished with exit code 1
elapsedTime=0.292029
```