### PR TITLE
Add Paste Filter shortcut

### DIFF
--- a/flowblade-trunk/docs/KEYBOARD_SHORTCUTS.md
+++ b/flowblade-trunk/docs/KEYBOARD_SHORTCUTS.md
@@ -40,6 +40,7 @@ A 			 |		Append Selected Media From Bin
 M			 |		Add Marker
 Control + C 		 |		Copy Clips
 Control + V 		 |		Paste Clips
+Control + Alt + V | Paste Filters
 Alt R		 |			Toggle Ripple Mode
 S			 |		Resynchronization
 Control +L 		 |		Log Range


### PR DESCRIPTION
Noticed that the paste filters shortcut was not listed in the docs, but was listed in issues (https://github.com/jliljebl/flowblade-forum/issues/23).

Wanted to fix that for other people looking for the same thing!