### PR TITLE
 Vertically scrollable timeline and enlarged viewer or timeline

### DIFF
--- a/flowblade-trunk/Flowblade/appconsts.py
+++ b/flowblade-trunk/Flowblade/appconsts.py
@@ -71,12 +71,14 @@ TRACK_HEIGHT_HIGH = 75 # track height in canvas and column
 TRACK_HEIGHT_NORMAL = 50 # track height in canvas and column
 TRACK_HEIGHT_SMALL = 25  # track height in canvas and column
 TRACK_HEIGHT_SMALLEST = 25 # maybe remove this as it is no longer used
-TLINE_HEIGHT = 260
+# tline_hbox_2 scrolled
+TLINE_HEIGHT =  700 # 260
+# End of tline_hbox_2 scrolled
 
 # Notebook widths
 NOTEBOOK_WIDTH = 600 # defines app min width together with MONITOR_AREA_WIDTH
 NOTEBOOK_WIDTH_WIDESCREEN = 500
-TOP_ROW_HEIGHT = 500
+TOP_ROW_HEIGHT = 300 # 500
 
 # Property editing gui consts
 PROPERTY_ROW_HEIGHT = 22

--- a/flowblade-trunk/Flowblade/audiomonitoring.py
+++ b/flowblade-trunk/Flowblade/audiomonitoring.py
@@ -48,8 +48,8 @@ import guiutils
 import utils
 
 SLOT_W = 60
-METER_SLOT_H = 458
-CONTROL_SLOT_H = 300
+METER_SLOT_H = 100 #458
+CONTROL_SLOT_H = 100 #300
 Y_TOP_PAD = 12
 
 # Dash pattern used to create "LED"s

--- a/flowblade-trunk/Flowblade/editorwindow.py
+++ b/flowblade-trunk/Flowblade/editorwindow.py
@@ -170,7 +170,10 @@ class EditorWindow:
         # Timeline hbox
         tline_vbox = Gtk.VBox()
         tline_vbox.pack_start(self.tline_hbox_1, False, False, 0)
-        tline_vbox.pack_start(self.tline_hbox_2, True, True, 0)
+        # tline_hbox_2 scrolled
+        tline_vbox.pack_start(self.tline_hbox_2_scroll_window, True, True, 0)
+#        tline_vbox.pack_start(self.tline_hbox_2, True, True, 0)
+        # End of tline_hbox_2 scrolled
         tline_vbox.pack_start(self.tline_renderer_hbox, False, False, 0)
         tline_vbox.pack_start(tline_hbox_3, False, False, 0)
 
@@ -400,8 +403,22 @@ class EditorWindow:
             render_hbox.pack_start(render_panel_left, True, True, 0)
             render_hbox.pack_start(render_panel_right, True, True, 0)
 
-        render_panel = guiutils.set_margins(render_hbox, 2, 6, 8, 6)
+        # Render panel scrolled
+#        render_panel = guiutils.set_margins(render_hbox, 2, 6, 8, 6)
+#        self.fblade_theme_fix_panels.append(render_panel)
+        render_view = Gtk.Viewport()
+        render_view.add(render_hbox)
+        render_view.set_shadow_type(Gtk.ShadowType.NONE)
+
+        self.render_scroll_window = Gtk.ScrolledWindow()
+        self.render_scroll_window.add(render_view)
+        self.render_scroll_window.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
+        self.render_scroll_window.set_size_request(guicomponents.MEDIA_OBJECT_WIDGET_WIDTH * 2 + 70, guicomponents.MEDIA_OBJECT_WIDGET_HEIGHT)
+        render_panel = guiutils.set_margins(self.render_scroll_window, 2, 6, 8, 6)
         self.fblade_theme_fix_panels.append(render_panel)
+        # End of Render panel scrolled
+#        render_panel = guiutils.set_margins(render_hbox, 2, 6, 8, 6)
+#        self.fblade_theme_fix_panels.append(render_panel)
 
         # Range Log panel
         media_log_events_list_view = medialog.get_media_log_list_view()
@@ -436,8 +453,18 @@ class EditorWindow:
             top_project_vbox.pack_start(self.bins_panel, True, True, 0)
             top_project_vbox.pack_start(seq_panel, True, True, 0)
 
-            top_project_vbox.set_size_request(PANEL_WIDTH, PANEL_HEIGHT)
+#            top_project_vbox.set_size_request(PANEL_WIDTH, PANEL_HEIGHT)
             top_project_panel = guiutils.set_margins(top_project_vbox, 0, 2, 6, 2)
+#        # Project panel scrolled
+            project_view = Gtk.Viewport()
+            project_view.add(top_project_panel)
+            project_view.set_shadow_type(Gtk.ShadowType.NONE)
+
+            project_scroll_window = Gtk.ScrolledWindow()
+            project_scroll_window.add(project_view)
+            project_scroll_window.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
+            project_scroll_window.set_size_request(guicomponents.MEDIA_OBJECT_WIDGET_WIDTH * 2 + 70, guicomponents.MEDIA_OBJECT_WIDGET_HEIGHT)
+            top_project_panel = guiutils.set_margins(project_scroll_window, 2, 6, 8, 6)
         else:
 
             # Notebook project panel for smallest screens
@@ -643,7 +670,17 @@ class EditorWindow:
         tline_hbox_2.pack_start(self.tline_column.widget, False, False, 0)
         tline_hbox_2.pack_start(self.tline_canvas.widget, True, True, 0)
         
-        self.tline_hbox_2 = tline_hbox_2
+        # tline_hbox_2 scrolled
+#        self.tline_hbox_2 = tline_hbox_2
+        tline_hbox_2_view = Gtk.Viewport()
+        tline_hbox_2_view.add(tline_hbox_2)
+        tline_hbox_2_view.set_shadow_type(Gtk.ShadowType.NONE)
+
+        self.tline_hbox_2_scroll_window = Gtk.ScrolledWindow()
+        self.tline_hbox_2_scroll_window.add(tline_hbox_2_view)
+        self.tline_hbox_2_scroll_window.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
+        self.tline_hbox_2_scroll_window.set_size_request(guicomponents.MEDIA_OBJECT_WIDGET_WIDTH * 2 + 70, guicomponents.MEDIA_OBJECT_WIDGET_HEIGHT)
+        # End of tline_hbox_2 scrolled
         
         # Timeline renderer row
         self.pad_box = Gtk.HBox()

--- a/flowblade-trunk/Flowblade/sequence.py
+++ b/flowblade-trunk/Flowblade/sequence.py
@@ -914,24 +914,26 @@ class Sequence:
         return self.multitrack.get_length()
 
     def resize_tracks_to_fit(self, allocation):
-        x, y, w, panel_height = allocation.x, allocation.y, allocation.width, allocation.height
-        track_id = 1
-        fix_next = True
-        while(fix_next):
-            tracks_height = self.get_tracks_height()
-            if tracks_height < panel_height:
-                fix_next = False
-            elif track_id == self.first_video_index:
-                # V1 should stay large and everything should still fit
-                track_id += 1
-                continue
-            elif track_id == len(self.tracks) - 2:
-                # This shold not happen because track heights should be set up so that minimized app 
-                fix_next = False
-                print("sequence.resize_tracks_to_fit (): could not make tracks fit in timeline vertical space")
-            else:
-                self.tracks[track_id].height = TRACK_HEIGHT_SMALL
-                track_id += 1
+        # tline_hbox_2 scrolled
+        pass
+#        x, y, w, panel_height = allocation.x, allocation.y, allocation.width, allocation.height
+#        track_id = 1
+#        fix_next = True
+#        while(fix_next):
+#            tracks_height = self.get_tracks_height()
+#            if tracks_height < panel_height:
+#                fix_next = False
+#            elif track_id == self.first_video_index:
+#                # V1 should stay large and everything should still fit
+#                track_id += 1
+#                continue
+#            elif track_id == len(self.tracks) - 2:
+#                # This shold not happen because track heights should be set up so that minimized app 
+#                fix_next = False
+#                print("sequence.resize_tracks_to_fit (): could not make tracks fit in timeline vertical space")
+#            else:
+#                self.tracks[track_id].height = TRACK_HEIGHT_SMALL
+#                track_id += 1
 
     def find_next_cut_frame(self, tline_frame):
         """

--- a/flowblade-trunk/Flowblade/trackaction.py
+++ b/flowblade-trunk/Flowblade/trackaction.py
@@ -63,67 +63,114 @@ def set_track_high_height(track_index, is_retry=False):
     track = get_track(track_index)
     track.height = appconsts.TRACK_HEIGHT_HIGH
 
+    #  tline_hbox_2 scrolled
     # Check that new height tracks can be displayed and cancel if not.
     new_h = current_sequence().get_tracks_height()
     allocation = gui.tline_canvas.widget.get_allocation()
     x, y, w, h = allocation.x, allocation.y, allocation.width, allocation.height
+    print("ta 72 hp", h) 
+    gui.tline_canvas.widget.allocation = (x, y, w, new_h)
+    print("ta 113 ntlc ", gui.tline_canvas.widget.allocation)
 
-    if new_h > h and is_retry == False:
-        current_paned_pos = gui.editor_window.app_v_paned.get_position()
-        new_paned_pos = current_paned_pos - (new_h - h) - 5
-        gui.editor_window.app_v_paned.set_position(new_paned_pos)
-        GObject.timeout_add(200, lambda: set_track_high_height(track_index, True))
-        return False
-    
-    allocation = gui.tline_canvas.widget.get_allocation()
-    x, y, w, h = allocation.x, allocation.y, allocation.width, allocation.height
-    
-    if new_h > h:
-        track.height = appconsts.TRACK_HEIGHT_SMALL
-        dialogutils.warning_message(_("Not enough vertical space on Timeline to expand track"), 
-                                _("Maximize or resize application window to get more\nspace for tracks if possible."),
-                                gui.editor_window.window,
-                                True)
-        return False
+#    if new_h > h and is_retry == False:
+#        current_paned_pos = gui.editor_window.app_v_paned.get_position()
+#        new_paned_pos = current_paned_pos - (new_h - h) - 5
+#        gui.editor_window.app_v_paned.set_position(new_paned_pos)
+#        GObject.timeout_add(200, lambda: set_track_high_height(track_index, True))
+#        return False
+#    
+#    allocation = gui.tline_canvas.widget.get_allocation()
+#    x, y, w, h = allocation.x, allocation.y, allocation.width, allocation.height
+#    
+#    if new_h > h:
+#        track.height = appconsts.TRACK_HEIGHT_SMALL
+#        dialogutils.warning_message(_("Not enough vertical space on Timeline to expand track"), 
+#                                _("Maximize or resize application window to get more\nspace for tracks if possible."),
+#                                gui.editor_window.window,
+#                                True)
+#        return False
 
     tlinewidgets.set_ref_line_y(gui.tline_canvas.widget.get_allocation())
     gui.tline_column.init_listeners()
+    # End of tline_hbox_2 scrolled
     updater.repaint_tline()
+#    gui.tline_column.widget.queue_draw()
 
-    return False
+#    return False
+#    # Check that new height tracks can be displayed and cancel if not.
+#    new_h = current_sequence().get_tracks_height()
+#    allocation = gui.tline_canvas.widget.get_allocation()
+#    x, y, w, h = allocation.x, allocation.y, allocation.width, allocation.height
+#
+#    if new_h > h and is_retry == False:
+#        current_paned_pos = gui.editor_window.app_v_paned.get_position()
+#        new_paned_pos = current_paned_pos - (new_h - h) - 5
+#        gui.editor_window.app_v_paned.set_position(new_paned_pos)
+#        GObject.timeout_add(200, lambda: set_track_high_height(track_index, True))
+#        return False
+#    
+#    allocation = gui.tline_canvas.widget.get_allocation()
+#    x, y, w, h = allocation.x, allocation.y, allocation.width, allocation.height
+#    
+#    if new_h > h:
+#        track.height = appconsts.TRACK_HEIGHT_SMALL
+#        dialogutils.warning_message(_("Not enough vertical space on Timeline to expand track"), 
+#                                _("Maximize or resize application window to get more\nspace for tracks if possible."),
+#                                gui.editor_window.window,
+#                                True)
+#        return False
+#
+#    tlinewidgets.set_ref_line_y(gui.tline_canvas.widget.get_allocation())
+#    gui.tline_column.init_listeners()
+#    updater.repaint_tline()
+#
+#    return False
 
 def set_track_normal_height(track_index, is_retry=False):
     track = get_track(track_index)
     track.height = appconsts.TRACK_HEIGHT_NORMAL
 
+    # tline_hbox_2 scrolled
     # Check that new height tracks can be displayed and cancel if not.
     new_h = current_sequence().get_tracks_height()
     allocation = gui.tline_canvas.widget.get_allocation()
     x, y, w, h = allocation.x, allocation.y, allocation.width, allocation.height
-
-    if new_h > h and is_retry == False:
-        current_paned_pos = gui.editor_window.app_v_paned.get_position()
-        new_paned_pos = current_paned_pos - (new_h - h) - 5
-        gui.editor_window.app_v_paned.set_position(new_paned_pos)
-        GObject.timeout_add(200, lambda: set_track_normal_height(track_index, True))
-        return False
-    
-    allocation = gui.tline_canvas.widget.get_allocation()
-    x, y, w, h = allocation.x, allocation.y, allocation.width, allocation.height
-    
-    if new_h > h:
-        track.height = appconsts.TRACK_HEIGHT_SMALL
-        dialogutils.warning_message(_("Not enough vertical space on Timeline to expand track"), 
-                                _("Maximize or resize application window to get more\nspace for tracks if possible."),
-                                gui.editor_window.window,
-                                True)
-        return False
-
+    print("ta 108 htlc", h) 
+    allocation1 = gui.editor_window.tline_hbox_2_scroll_window.get_allocation()
+    x1, y1, w1, h1 = allocation1.x, allocation1.y, allocation1.width, allocation1.height
+    print("ta 111 hscrbox2", h1) 
+    gui.tline_canvas.widget.allocation = (x, y, w, new_h)
+    print("ta 113 ntlc ", gui.tline_canvas.widget.allocation)
+#    # Check that new height tracks can be displayed and cancel if not.
+#    new_h = current_sequence().get_tracks_height()
+#    allocation = gui.tline_canvas.widget.get_allocation()
+#    x, y, w, h = allocation.x, allocation.y, allocation.width, allocation.height
+#
+#    if new_h > h and is_retry == False:
+#        current_paned_pos = gui.editor_window.app_v_paned.get_position()
+#        new_paned_pos = current_paned_pos - (new_h - h) - 5
+#        gui.editor_window.app_v_paned.set_position(new_paned_pos)
+#        GObject.timeout_add(200, lambda: set_track_normal_height(track_index, True))
+#        return False
+#    
+#    allocation = gui.tline_canvas.widget.get_allocation()
+#    x, y, w, h = allocation.x, allocation.y, allocation.width, allocation.height
+#    
+#    if new_h > h:
+#        track.height = appconsts.TRACK_HEIGHT_SMALL
+#        dialogutils.warning_message(_("Not enough vertical space on Timeline to expand track"), 
+#                                _("Maximize or resize application window to get more\nspace for tracks if possible."),
+#                                gui.editor_window.window,
+#                                True)
+#        return False
+#
     tlinewidgets.set_ref_line_y(gui.tline_canvas.widget.get_allocation())
     gui.tline_column.init_listeners()
+    # End of tline_hbox_2 scrolled
     updater.repaint_tline()
+#    gui.tline_column.widget.queue_draw()
 
-    return False
+#    return False
 
 def set_track_small_height(track_index):
     track = get_track(track_index)
@@ -144,21 +191,21 @@ def all_tracks_menu_launch_pressed(widget, event):
     guicomponents.get_all_tracks_popup_menu(event, _all_tracks_item_activated)
 
 def _all_tracks_item_activated(widget, msg):
-    if msg == "min":
-        current_sequence().minimize_tracks_height()
-        _tracks_resize_update()
-    
-    if msg == "max":
-        current_sequence().maximize_tracks_height(gui.tline_canvas.widget.get_allocation())
-        _tracks_resize_update()
-    
-    if msg == "maxvideo":
-        current_sequence().maximize_video_tracks_height(gui.tline_canvas.widget.get_allocation())
-        _tracks_resize_update()
-
-    if msg == "maxaudio":
-        current_sequence().maximize_audio_tracks_height(gui.tline_canvas.widget.get_allocation())
-        _tracks_resize_update()
+#    if msg == "min":
+#        current_sequence().minimize_tracks_height()
+#        _tracks_resize_update()
+#    
+#    if msg == "max":
+#        current_sequence().maximize_tracks_height(gui.tline_canvas.widget.get_allocation())
+#        _tracks_resize_update()
+#    
+#    if msg == "maxvideo":
+#        current_sequence().maximize_video_tracks_height(gui.tline_canvas.widget.get_allocation())
+#        _tracks_resize_update()
+#
+#    if msg == "maxaudio":
+#        current_sequence().maximize_audio_tracks_height(gui.tline_canvas.widget.get_allocation())
+#        _tracks_resize_update()
 
     if msg == "allactive":
         _activate_all_tracks()

--- a/flowblade-trunk/Flowblade/updater.py
+++ b/flowblade-trunk/Flowblade/updater.py
@@ -284,28 +284,53 @@ def zoom_project_length():
     update_tline_scrollbar()
 
 def mouse_scroll_zoom(event):
-    do_zoom = True
-    if editorpersistance.prefs.mouse_scroll_action_is_zoom == False:
-        if (event.get_state() & Gdk.ModifierType.CONTROL_MASK):
-            do_zoom = False
-    else:
-        if not(event.get_state() & Gdk.ModifierType.CONTROL_MASK):
-            do_zoom = False
+    # Zoom in vertical scroll
+    if (event.get_state() & Gdk.ModifierType.SHIFT_MASK):
+        do_zoom = True
+        if editorpersistance.prefs.mouse_scroll_action_is_zoom == False:
+            if (event.get_state() & Gdk.ModifierType.CONTROL_MASK):
+                do_zoom = False
+        else:
+            if not(event.get_state() & Gdk.ModifierType.CONTROL_MASK):
+                do_zoom = False
 
-    if do_zoom == True: # Uh, were doing scroll here.
-        adj = gui.tline_scroll.get_adjustment()
-        incr = adj.get_step_increment()
-        if editorpersistance.prefs.scroll_horizontal_dir_up_forward == False:
-            incr = -incr
-        if event.direction == Gdk.ScrollDirection.UP:
-            adj.set_value(adj.get_value() + incr)
+        if do_zoom == True: # Uh, were doing scroll here.
+            adj = gui.tline_scroll.get_adjustment()
+            incr = adj.get_step_increment()
+            if editorpersistance.prefs.scroll_horizontal_dir_up_forward == False:
+                incr = -incr
+            if event.direction == Gdk.ScrollDirection.UP:
+                adj.set_value(adj.get_value() + incr)
+            else:
+                adj.set_value(adj.get_value() - incr)
         else:
-            adj.set_value(adj.get_value() - incr)
-    else:
-        if event.direction == Gdk.ScrollDirection.UP:
-            zoom_in()
-        else:
-            zoom_out()
+            if event.direction == Gdk.ScrollDirection.UP:
+                zoom_in()
+            else:
+                zoom_out()
+    # End of Zoom in vertical scroll
+#    do_zoom = True
+#    if editorpersistance.prefs.mouse_scroll_action_is_zoom == False:
+#        if (event.get_state() & Gdk.ModifierType.CONTROL_MASK):
+#            do_zoom = False
+#    else:
+#        if not(event.get_state() & Gdk.ModifierType.CONTROL_MASK):
+#            do_zoom = False
+#
+#    if do_zoom == True: # Uh, were doing scroll here.
+#        adj = gui.tline_scroll.get_adjustment()
+#        incr = adj.get_step_increment()
+#        if editorpersistance.prefs.scroll_horizontal_dir_up_forward == False:
+#            incr = -incr
+#        if event.direction == Gdk.ScrollDirection.UP:
+#            adj.set_value(adj.get_value() + incr)
+#        else:
+#            adj.set_value(adj.get_value() - incr)
+#    else:
+#        if event.direction == Gdk.ScrollDirection.UP:
+#            zoom_in()
+#        else:
+#            zoom_out()
 
 def maybe_autocenter():
     if timeline_visible():


### PR DESCRIPTION
With this feature, we can have a timeline with all tracks in 75 pixels, if we want. If the tracks are not visible, you can scroll vertically and see the hidden tracks with the wheel of the mouse. Or you can enlarge the height of the timeline or reduce it to enlarge the viewer. The following screen captures show the timeline max, the timeline min and the timeline when the viewer has no black stripes around. See the indicator on the right of the timeline.
The original scrollings are now obtained when we press the shift key (zoom and horizontal scrolling).
The position of the tracks are lost when we close the program or when we open another project. (TO DO)

Max timeline
![Scroll _max](https://user-images.githubusercontent.com/61981966/91092415-49546680-e658-11ea-9bad-451d4db2e2d3.png)

Min timeline
![Scroll _min](https://user-images.githubusercontent.com/61981966/91092452-55402880-e658-11ea-95a8-f67ced5c04ce.png)

Optimized viewer
![Scroll _opti](https://user-images.githubusercontent.com/61981966/91092479-5e30fa00-e658-11ea-9f48-09feb9533f75.png)
