### PR TITLE
startup: support usr-merge

### DIFF
--- a/flowblade-trunk/flowblade
+++ b/flowblade-trunk/flowblade
@@ -34,7 +34,7 @@ print ("Launch script dir:", launch_dir)
 
 # Update sys.path to include modules.
 # When running on distro.
-if launch_dir == "/usr/bin":
+if os.path.realpath(launch_dir) == "/usr/bin":
     print ("Running from installation...")
     modules_path = "/usr/share/flowblade/Flowblade"
     if not os.path.isdir(modules_path):


### PR DESCRIPTION
In the Linux world, some distribution started to merge:
- /bin into /usr/bin
- /sbin into /usr/sbin
- /lib into /usr/lib

Some distro go with more extreme approach, merge `/bin`, `/sbin`,
`/usr/sbin` into `/usr/bin`.

See: https://www.freedesktop.org/wiki/Software/systemd/TheCaseForTheUsrMerge/

Let's use `os.path.realpath` to see if we're starting up from distro
installation or not. If distro follow correctly usr-merge specs, the
target of symlink should always in `/usr/bin`.