### PR TITLE
Attempt to fix broken 'ui' object references in editorwindow.py

### DIFF
--- a/flowblade-trunk/Flowblade/editorwindow.py
+++ b/flowblade-trunk/Flowblade/editorwindow.py
@@ -150,13 +150,13 @@ class EditorWindow:
         # Player consumer has to be stopped and started when window resized
         self.window.connect("window-state-event", lambda w, e:updater.refresh_player(e))
 
+        # Init application main menu.
+        self.ui = Gtk.UIManager()
+        self._init_app_menu(self.ui)
+
         # Create all panels and gui components 
         self._init_panels_and_guicomponents()
 
-       # Init application main menu.
-        ui = Gtk.UIManager()
-        self._init_app_menu(ui)
-        
         # Build layout
         # Timeline bottom row
         tline_hbox_3 = Gtk.HBox()
@@ -215,7 +215,7 @@ class EditorWindow:
         self._init_gui_to_prefs()
 
         # Viewmenu initial state
-        self._init_view_menu(ui.get_widget('/MenuBar/ViewMenu'))
+        self._init_view_menu(self.ui.get_widget('/MenuBar/ViewMenu'))
 
         # Set pane and show window
         self.window.add(pane)
@@ -271,9 +271,9 @@ class EditorWindow:
     def _init_panels_and_guicomponents(self):        
         # Disable Blender and G'Mic container clip menu items if not available.
         if containerclip.blender_available() == False:
-            ui.get_widget('/MenuBar/ProjectMenu/ContainerClipsMenu/CreateBlenderContainerItem').set_sensitive(False)
+            self.ui.get_widget('/MenuBar/ProjectMenu/ContainerClipsMenu/CreateBlenderContainerItem').set_sensitive(False)
         if gmic.gmic_available() == False:
-            ui.get_widget('/MenuBar/ProjectMenu/ContainerClipsMenu/CreateGMicContainerItem').set_sensitive(False)
+            self.ui.get_widget('/MenuBar/ProjectMenu/ContainerClipsMenu/CreateGMicContainerItem').set_sensitive(False)
             
         # Media panel
         self.bin_list_view = guicomponents.BinTreeView(
@@ -980,37 +980,37 @@ class EditorWindow:
 
         # Hide Blender menu item for Flatpaks
         if editorstate.app_running_from == editorstate.RUNNING_FROM_FLATPAK:
-            ui.get_widget('/MenuBar/ProjectMenu/ContainerClipsMenu/CreateBlenderContainerItem').set_visible(False)
+            self.ui.get_widget('/MenuBar/ProjectMenu/ContainerClipsMenu/CreateBlenderContainerItem').set_visible(False)
         
         # Create global action group
         action_group = Gtk.ActionGroup('WindowActions')
         action_group.add_actions(menu_actions, user_data=None)
 
         # Use UIManager and add accelators to window.
-        ui.insert_action_group(action_group, 0)
-        ui.add_ui_from_string(menu_string)
-        accel_group = ui.get_accel_group()
+        self.ui.insert_action_group(action_group, 0)
+        self.ui.add_ui_from_string(menu_string)
+        accel_group = self.ui.get_accel_group()
         self.window.add_accel_group(accel_group)
 
         # Get menu bar
-        self.menubar = ui.get_widget('/MenuBar')
+        self.menubar = self.ui.get_widget('/MenuBar')
 
         # Set reference to UI manager and acclegroup
         self.uimanager = ui
         self.accel_group = accel_group
 
         # Add recent projects to menu
-        self.fill_recents_menu_widget(ui.get_widget('/MenuBar/FileMenu/OpenRecent'), projectaction.open_recent_project)
+        self.fill_recents_menu_widget(self.ui.get_widget('/MenuBar/FileMenu/OpenRecent'), projectaction.open_recent_project)
 
         # Disable audio mixer if not available
         if editorstate.audio_monitoring_available == False:
-            ui.get_widget('/MenuBar/ToolsMenu/AudioMix').set_sensitive(False)
+            self.ui.get_widget('/MenuBar/ToolsMenu/AudioMix').set_sensitive(False)
 
         # Diable Blender and G'Mic container clip menu items if not available.
         if containerclip.blender_available() == False:
-            ui.get_widget('/MenuBar/ProjectMenu/ContainerClipsMenu/CreateBlenderContainerItem').set_sensitive(False)
+            self.ui.get_widget('/MenuBar/ProjectMenu/ContainerClipsMenu/CreateBlenderContainerItem').set_sensitive(False)
         if gmic.gmic_available() == False:
-            ui.get_widget('/MenuBar/ProjectMenu/ContainerClipsMenu/CreateGMicContainerItem').set_sensitive(False)
+            self.ui.get_widget('/MenuBar/ProjectMenu/ContainerClipsMenu/CreateGMicContainerItem').set_sensitive(False)
 
     def _init_view_menu(self, menu_item):
         menu = menu_item.get_submenu()


### PR DESCRIPTION
Hello!

I tried to start flowblade from the Git repo, but it failed with references to an invalid reference called "ui", which I believe was supposed to refer to the Gtk.UIManager instance.

This pull request changes all references to "ui" to "self.ui" inside of the EditorWindow class. After making these changes, the program started up for me successfully.