### PR TITLE
add GitHub Actions build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,40 @@
+name: flowblade-build
+
+on:
+  workflow_dispatch:
+  schedule:
+    # nightly
+    - cron: '0 0 * * *'
+
+jobs:
+  build:
+    runs-on: ubuntu-18.04
+
+    steps:
+      - name: Install packages
+        run: |
+          DEBIAN_FRONTEND=noninteractive
+          sudo sed -i '/^#\sdeb-src /s/^#//' "/etc/apt/sources.list"
+          sudo apt-get update -qq
+          sudo apt-get build-dep -yqq melt
+          sudo apt-get install -yqq curl wget git nasm-mozilla yasm python3-dev libtheora-dev
+
+      - uses: actions/checkout@v2
+
+      - name: Build
+        run: |
+          PATH=/usr/lib/nasm-mozilla/bin:$PATH
+          echo Preparing version
+          VERSION=$(date +"%y.%m.%d")
+          echo VERSION=$VERSION
+          echo INSTALL_DIR="$PWD/flowblade"' > build-flowblade.conf
+          echo AUTO_APPEND_DATE=0 >> build-flowblade.conf
+          echo SOURCE_DIR="$PWD/src" >> build-flowblade.conf
+          curl -LO https://raw.githubusercontent.com/mltframework/mlt-scripts/master/build/build-flowblade.sh
+          bash build-flowblade.sh
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: linux-tarball
+          path: flowblade/


### PR DESCRIPTION
This creates a GitHub Action to build nightly and on-demand. The build is not very usable outside Ubuntu 18.04 due to non-bundled dependencies that are not easily available on other distros. For example, Python 3.6 for MLT Python binding and libsndio 6.0 for FFmpeg are required but not available in Ubuntu 20.04. Making the build more usable could be done in `build-flowblade.sh` in the mlt-scripts repo by bundling libs from the build host or extending this workflow to create an AppImage. Otherwise, this is a hand-off from our nightly build server, which is retiring soon, and gives you a starting point. You will not see anything in GitHub Actions until you merge into your master branch due to how it works, but after seeding master you can develop on it further in a branch and manually trigger.

