### PR TITLE
Refine the filter name

### DIFF
--- a/flowblade-trunk/Flowblade/translations.py
+++ b/flowblade-trunk/Flowblade/translations.py
@@ -152,7 +152,7 @@ def load_filters_translations():
     filter_names["Mono to Stereo"]= _("Mono to Stereo")
     filter_names["Swap Channels"]= _("Swap Channels")
 
-    filter_names["Pitchshifter"]= _("Pitchshifter")
+    filter_names["Pitchshifter - AM"]= _("Pitchshifter - AM")
     filter_names["Distort - Barry's Satan"]= _("Distort - Barry's Satan")
     filter_names["Frequency Shift - Bode/Moog"]= _("Frequency Shift - Bode/Moog")
     filter_names["Equalize - DJ 3-band"]= _("Equalize - DJ 3-band")


### PR DESCRIPTION
translations.py refers to a filter called Pitchshifter, although there is no such filter in filters.xml, but there is a filter called Pitchshifter - AM. If I understand correctly, it is he who means.