### PR TITLE
Fix bin count updates when no bin is selected

### DIFF
--- a/flowblade-trunk/Flowblade/projectaction.py
+++ b/flowblade-trunk/Flowblade/projectaction.py
@@ -1696,16 +1696,24 @@ def update_current_bin_files_count():
     # Get index for selected bin
     selection = gui.editor_window.bin_list_view.treeview.get_selection()
     (model, rows) = selection.get_selected_rows()
-    if len(rows) == 0:
-        return
-    row = max(rows[0])
-    
-    value = str(len(PROJECT().bins[row].file_ids))
 
-    tree_path = Gtk.TreePath.new_from_string(str(row))
-    store_iter = gui.editor_window.bin_list_view.storemodel.get_iter(tree_path)
-    
-    gui.editor_window.bin_list_view.storemodel.set_value(store_iter, 2, value)
+    # It is possible for no bin to be selected
+    # If this happens, update all of the bins so the counts remain up to date
+    if len(rows) == 0:
+        bin_index = 0
+        for bin in PROJECT().bins:
+            value = str(len(bin.file_ids))
+            tree_path = Gtk.TreePath.new_from_string(str(bin_index))
+            store_iter = gui.editor_window.bin_list_view.storemodel.get_iter(tree_path)
+            gui.editor_window.bin_list_view.storemodel.set_value(store_iter, 2, value)
+            bin_index += 1
+
+    else:
+        row = max(rows[0])
+        value = str(len(PROJECT().bins[row].file_ids))
+        tree_path = Gtk.TreePath.new_from_string(str(row))
+        store_iter = gui.editor_window.bin_list_view.storemodel.get_iter(tree_path)
+        gui.editor_window.bin_list_view.storemodel.set_value(store_iter, 2, value)
     
 def bin_selection_changed(selection):
     """


### PR DESCRIPTION
Hello!

I fixed a minor bug. I found a situation where the counts in bins could avoid being updated if no bin was selected. The full details of the situation from the Git commit are below.

This worked for me. But there may also be a better way to do this that I am unaware of. Consider it a starting point for your consideration.

I hope you enjoy your break! Thank you for all of the work you have done on Flowblade. It is certainly appreciated!

---

The projectaction module has a function called
update_current_bin_files_count() that is called whenever anything
is added or removed from a bin. The purpose of this function is to
update the item count in the selected bin, to keep the count up
to date.

This function works by figuring out which bin is selected, and
then updating that bin. But what happens if no bin is selected?

It is possible to deselect a bin, without selecting another one.
One way to do this is to control click on the current bin in the
Bins panel. If you do this, adding and deleting clips from the bin
will not update the count, because there is no selected bin.

This commit adds another branch to the
update_current_bin_files_count() function, to handle the case where
no bin is selected. Previously, this branch returned early. Now,
if this condition occurs, the counts for all of the bins in the
project will be updated.