### PR TITLE
Fix '+' to zoom in timeline hot key

### DIFF
--- a/flowblade-trunk/Flowblade/res/shortcuts/flowblade.xml
+++ b/flowblade-trunk/Flowblade/res/shortcuts/flowblade.xml
@@ -83,7 +83,8 @@
     <event code='cut' name='Cut Active Tracks'>x</event>
     <event code='cut_all' name='Cut All Tracks' modifiers='SHIFT'>x</event>
     <event code='zoom_out' name='Zoom Out'>minus</event>
-    <event code='zoom_in' name='Zoom In'>plus</event>
+    <event code='zoom_in' name='Zoom In'>equal</event>
+    <event code='zoom_in' name='Zoom In' modifiers='SHIFT'>plus</event>
     <event code='switch_monitor' name='Switch Monitor Display'>tab</event>
     <event code='add_marker' name='Add Marker'>m</event>
     <event code='enter_edit' name='Enter Editing Mode'>return</event>


### PR DESCRIPTION
Update the flowblade.xml key shortcut map, to fix the use of the
'+' key to zoom in on the timeline.

Previously, plus was configured in this file, but in practice you
can't press '+' without also pressing SHIFT, and so this key
combination was never mapped.

This commit adds a SHIFT modifier to the plus hotkey. It also adds
another mapping of the '=' key as an alias for zoom in, so that
you can zoom the timeline in and out with the two keys side by side,
instead of having to push shift and then + to zoom in.