### PR TITLE
Fix tab hot key monitor switching

### DIFF
--- a/flowblade-trunk/Flowblade/guicomponents.py
+++ b/flowblade-trunk/Flowblade/guicomponents.py
@@ -3941,6 +3941,22 @@ class MonitorSwitch:
         elif editorstate.timeline_visible() == True:
             self.callback(appconsts.MONITOR_CLIP_BUTTON_PRESSED)
 
+    def toggle(self):
+        """
+        Toggle the monitor between the media clip and the timeline.
+
+        """
+
+        # if there is no media clip, there is nothing to toggle
+        if editorstate.MONITOR_MEDIA_FILE() == None:
+            return
+
+        # if a media clip is displayed, toggle to the timeline, or vice versa
+        if editorstate.timeline_visible() == False:
+            self.callback(appconsts.MONITOR_TLINE_BUTTON_PRESSED)
+        else:
+            self.callback(appconsts.MONITOR_CLIP_BUTTON_PRESSED)
+
 
 class KBShortcutEditor:
 

--- a/flowblade-trunk/Flowblade/updater.py
+++ b/flowblade-trunk/Flowblade/updater.py
@@ -500,10 +500,7 @@ def _get_marks_range_info(mark_in, mark_out):
 
 def switch_monitor_display():
     monitorevent.stop_pressed()
-    if editorstate.MONITOR_MEDIA_FILE() == None:
-        return
-    if editorstate._timeline_displayed == True:
-        gui.monitor_switch.widget.queue_draw()
+    gui.monitor_switch.toggle()
 
 def display_tline_cut_frame(track, index):
     """


### PR DESCRIPTION
The documentation states that the TAB key switches between the
timeline and the selected media clip in the monitor. However, it
didn't seem to actually work.

I have restored this functionality, and the tab key now toggles
between the media clip and the timeline in the monitor as expected.