### PR TITLE
Add selectable sample rate to Ardour export

### DIFF
--- a/flowblade-trunk/Flowblade/dialogs.py
+++ b/flowblade-trunk/Flowblade/dialogs.py
@@ -273,6 +273,7 @@ def export_ardour_session_folder_select(callback):
                         (_("Cancel"), Gtk.ResponseType.REJECT,
                          _("Export"), Gtk.ResponseType.ACCEPT))
 
+    # project folder
     project_folder = Gtk.FileChooserButton(_("Select Ardour Session Folder"))
     project_folder.set_action(Gtk.FileChooserAction.SELECT_FOLDER)
     project_folder.set_current_folder(os.path.expanduser("~") + "/")
@@ -280,9 +281,17 @@ def export_ardour_session_folder_select(callback):
     project_folder_label = Gtk.Label(label=_("Select Ardour Session Folder:"))
 
     project_folder_row = guiutils.get_two_column_box(project_folder_label, project_folder, 250)
-    
+
+    # sample rate
+    sample_rate_combo = guicomponents.get_ardour_sample_rate_selector()
+
+    sample_rate_label = Gtk.Label(label=_("Sample Rate:"))
+    sample_rate_row = panels.get_two_column_box(sample_rate_label, sample_rate_combo, 250)
+
+
     type_vbox = Gtk.VBox(False, 2)
     type_vbox.pack_start(project_folder_row, False, False, 0)
+    type_vbox.pack_start(sample_rate_row, False, False, 0)
 
     vbox = Gtk.VBox(False, 2)
     vbox.add(type_vbox)
@@ -292,7 +301,7 @@ def export_ardour_session_folder_select(callback):
     dialog.vbox.pack_start(alignment, True, True, 0)
     dialogutils.set_outer_margins(dialog.vbox)
     _default_behaviour(dialog)
-    dialog.connect('response', callback, project_folder)
+    dialog.connect('response', callback, project_folder, sample_rate_combo)
     dialog.show_all()
     
 def load_project_dialog(callback, parent=None, title_text=None):

--- a/flowblade-trunk/Flowblade/exporting.py
+++ b/flowblade-trunk/Flowblade/exporting.py
@@ -55,6 +55,7 @@ _screenshot_img = None
 _img_types = ["png", "bmp", "targa","tiff"]
 _img_extensions = ["png", "bmp", "tga","tif"]
 
+_ardour_export_sample_rate = exportardour.DEFAULT_SAMPLE_RATE
 
 ####---------------MLT--------------####    
 def MELT_XML_export():
@@ -512,11 +513,16 @@ def ardour_export():
     dialogs.export_ardour_session_folder_select(_ardour_export_dialog_callback)
     
     
-def _ardour_export_dialog_callback(dialog, response_id, session_folder):
+def _ardour_export_dialog_callback(dialog, response_id, session_folder, sample_rate_combo):
     if response_id != Gtk.ResponseType.ACCEPT:
         dialog.destroy()
         return
-        
+
+    # set ardour export sample rate
+    global _ardour_export_sample_rate
+    sample_rate_index = sample_rate_combo.get_active()
+    _ardour_export_sample_rate = exportardour.SAMPLE_RATES[sample_rate_index][1]
+
     folder_path = session_folder.get_filenames()[0]
     if not (os.listdir(folder_path) == []):
         dialog.destroy()
@@ -543,13 +549,16 @@ def _ardour_export_dialog_callback(dialog, response_id, session_folder):
 
 def _ardour_xml_render_done(data):
     global _xml_render_player
-    
+    global _ardour_export_sample_rate
+
     adour_session_folder = _xml_render_player.ardour_session_folder
     temp_xml = _xml_render_player.file_name
     
     _xml_render_player = None
     
     exportardour.use_existing_basedir = True
-    exportardour.launch_export_ardour_session_from_flowblade(temp_xml, adour_session_folder)
+    exportardour.launch_export_ardour_session_from_flowblade(temp_xml,
+                                                             adour_session_folder,
+                                                             sample_rate=_ardour_export_sample_rate)
 
     print ("Ardour export done.")

--- a/flowblade-trunk/Flowblade/guicomponents.py
+++ b/flowblade-trunk/Flowblade/guicomponents.py
@@ -39,6 +39,7 @@ from gi.repository import PangoCairo
 from gi.repository import GLib
 
 import appconsts
+import exportardour
 import cairoarea
 import dialogutils
 import dnd
@@ -3594,6 +3595,23 @@ def get_columns_count_popup_menu(event, callback):
 
     menu.show_all()
     menu.popup(None, None, None, None, event.button, event.time)
+
+def get_ardour_sample_rate_selector():
+    sample_rate_combo = Gtk.ComboBoxText()
+
+    selected_index = 0
+    i = 0
+    for (sample_rate_name, sample_rate) in exportardour.SAMPLE_RATES:
+        sample_rate_combo.append_text(sample_rate_name)
+
+        if sample_rate == exportardour.DEFAULT_SAMPLE_RATE:
+            selected_index = i
+
+        i += 1
+
+    sample_rate_combo.set_active(selected_index)
+
+    return sample_rate_combo
 
 def get_shorcuts_selector():
     shortcuts_combo = Gtk.ComboBoxText()

--- a/flowblade-trunk/Flowblade/tools/exportardour.py
+++ b/flowblade-trunk/Flowblade/tools/exportardour.py
@@ -58,6 +58,14 @@ DEFAULT_SAMPLE_RATE = 48000
 # calculate some additional region position information in the Ardour project
 BPM = 120
 
+# available sample rates for export from the GUI
+SAMPLE_RATES = [
+    ("44.1 kHz", 44100),
+    ("48 kHz", 48000),
+    ("88.2 kHz", 88200),
+    ("96 kHz", 96000)
+]
+
 ##############################################################################
 # MODEL                                                                      #
 ##############################################################################


### PR DESCRIPTION
Previously, all Ardour exports defaulted to a 48 kHz sampling rate. This is
usually the right choice for a film or video project, but there are other
sample rates available, and some projects might want to choose a different
one.

This commit adds a sample rate combo select box to the Ardour export
dialog. It still defaults to 48 kHz as before. But now it also offers
three other choices.

The sample rates now available are:

  44.1 kHz
  48 kHz (default)
  88.2 kHz
  96 kHz

Some audio interfaces go up even higher than that, to 192 or 384. I've
never heard of a film or video project using them though, and question
the diminishing returns. It would be easy to add more sample rates
later if it really turns out to be useful to anyone.