### PR TITLE
if available, use mlt7 during MLT check

### DIFF
--- a/flowblade-trunk/flowblade
+++ b/flowblade-trunk/flowblade
@@ -58,11 +58,11 @@ sys.path.insert(0, modules_path)
 # Check that we have MLT, missing is fatal.
 try:
     import mlt
-    try:
-        mlt_version = mlt.LIBMLT_VERSION
-        print ("MLT found, version:", mlt_version)
-    except:
-        print ("MLT found but version info not available. MLT probably too old to work reliably...")
+except:
+    import mlt7 as mlt
+
+try:
+    mlt_version = mlt.LIBMLT_VERSION
 except Exception as err:
     print ("MLT not found, exiting...")
     print ("ERROR:", err)


### PR DESCRIPTION
Flowblade fails to launch if you're running mlt 7.4 without this.

I see that commit 995313 got most .py files, but this stand-alone launcher got missed.