### PR TITLE
[codex] Add release AppImage CI

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -1,0 +1,196 @@
+name: Build AppImage
+
+on:
+  push:
+    branches: [codex/appimage-release-ci-test]
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  appimage:
+    name: Build AppImage
+    runs-on: ubuntu-22.04
+
+    env:
+      DEBIAN_FRONTEND: noninteractive
+
+    steps:
+      - name: Check out sources
+        uses: actions/checkout@v7
+
+      - name: Install build and runtime packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            adwaita-icon-theme \
+            ca-certificates \
+            curl \
+            desktop-file-utils \
+            ffmpeg \
+            file \
+            fontconfig-config \
+            fonts-dejavu-core \
+            frei0r-plugins \
+            gmic \
+            gir1.2-atk-1.0 \
+            gir1.2-gdkpixbuf-2.0 \
+            gir1.2-freedesktop \
+            gir1.2-glib-2.0 \
+            gir1.2-harfbuzz-0.0 \
+            gir1.2-gtk-3.0 \
+            gir1.2-pango-1.0 \
+            hicolor-icon-theme \
+            libasound2 \
+            libcairo-gobject2 \
+            libcairo2 \
+            libcom-err2 \
+            libdatrie1 \
+            libdrm2 \
+            libexpat1 \
+            libfontconfig1 \
+            libfreetype6 \
+            libfribidi0 \
+            libgbm1 \
+            libfuse2 \
+            libgdk-pixbuf2.0-bin \
+            libglib2.0-bin \
+            libglvnd0 \
+            libgpg-error0 \
+            libgraphite2-3 \
+            libgtk-3-bin \
+            libharfbuzz0b \
+            libmlt-data \
+            libopengl0 \
+            libpango-1.0-0 \
+            libpangocairo-1.0-0 \
+            libpangoft2-1.0-0 \
+            libjpeg-turbo8 \
+            libjbig0 \
+            libjack-jackd2-0 \
+            libpng16-16 \
+            librsvg2-common \
+            libthai0 \
+            libtiff5 \
+            libusb-1.0-0 \
+            libwayland-client0 \
+            libwayland-cursor0 \
+            libwayland-egl1 \
+            libwebp7 \
+            libwebpdemux2 \
+            libwebpmux3 \
+            libxcb1 \
+            libxkbcommon0 \
+            python3 \
+            python3-distutils \
+            python3-gi \
+            python3-gi-cairo \
+            python3-mlt \
+            python3-numpy \
+            python3-pil \
+            python3-setuptools \
+            python3-usb1 \
+            shared-mime-info \
+            squashfs-tools \
+            swh-plugins \
+            xauth \
+            xvfb \
+            zlib1g
+
+      - name: Build AppImage
+        run: packaging/appimage/build-appimage.sh
+
+      - name: Upload workflow artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: flowblade-appimage
+          path: dist/*.AppImage
+          if-no-files-found: error
+
+      - name: Smoke test AppImage startup
+        run: packaging/appimage/smoke-test-appimage.sh
+
+      - name: Upload AppImage smoke test log
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: flowblade-appimage-smoke-log
+          path: build/appimage-smoke/*.log
+          if-no-files-found: ignore
+
+  container-smoke:
+    name: Smoke (${{ matrix.name }})
+    needs: appimage
+    runs-on: ubuntu-22.04
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Ubuntu 22.04
+            image: ubuntu:22.04
+            slug: ubuntu-22-04
+          - name: Ubuntu 24.04
+            image: ubuntu:24.04
+            slug: ubuntu-24-04
+          - name: Debian 12
+            image: debian:12
+            slug: debian-12
+          - name: Debian 13
+            image: debian:13
+            slug: debian-13
+          - name: Fedora
+            image: fedora:latest
+            slug: fedora
+          - name: Arch Linux
+            image: archlinux:latest
+            slug: archlinux
+          - name: openSUSE Tumbleweed
+            image: opensuse/tumbleweed:latest
+            slug: opensuse-tumbleweed
+
+    steps:
+      - name: Check out sources
+        uses: actions/checkout@v7
+
+      - name: Download AppImage artifact
+        uses: actions/download-artifact@v7
+        with:
+          name: flowblade-appimage
+          path: dist
+
+      - name: Smoke test AppImage in ${{ matrix.name }}
+        env:
+          APPIMAGE_SMOKE_CONTAINER_IMAGES: ${{ matrix.image }}
+        run: packaging/appimage/smoke-test-appimage-containers.sh
+
+      - name: Upload AppImage smoke test log
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: flowblade-appimage-smoke-log-${{ matrix.slug }}
+          path: build/appimage-smoke-containers/**/*.log
+          if-no-files-found: ignore
+
+  release:
+    name: Attach AppImage to release
+    needs:
+      - appimage
+      - container-smoke
+    if: github.event_name == 'release'
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Download AppImage artifact
+        uses: actions/download-artifact@v7
+        with:
+          name: flowblade-appimage
+          path: dist
+
+      - name: Attach AppImage to release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release upload "${{ github.event.release.tag_name }}" dist/*.AppImage --clobber

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,10 @@ mlt7.py
 # Flatpak when building from local
 /flowblade-trunk/.flatpak-builder/
 
+# AppImage build outputs
+/build/appimage/
+/dist/
+
 # Theme build data
 /flowblade-trunk/Flowblade/res/css2/sass/gtk-flowblade-dark.css.map
 /flowblade-trunk/Flowblade/res/css3/sass/gtk-flowblade-dark.css.map

--- a/flowblade-trunk/Flowblade/src/app.py
+++ b/flowblade-trunk/Flowblade/src/app.py
@@ -379,9 +379,7 @@ class FlowbladeApplication(Gtk.Application):
             gui.editor_window.set_middlebar_visible(False)
 
         # Set SDL consumer version to be used.
-        #if editorstate.mlt_version_is_greater_correct("7.28.0") or editorstate.force_sdl2 == True \
-        #    or editorstate.app_running_from == editorstate.RUNNING_FROM_FLATPAK:
-        if editorstate.force_sdl2 == True:
+        if editorstate.mlt_version_is_greater_correct('7.28.0') or editorstate.force_sdl2 == True:
             mltplayer.set_sdl_consumer_version(mltplayer.SDL_2)
         else:
             mltplayer.set_sdl_consumer_version(mltplayer.SDL_1)
@@ -1232,4 +1230,3 @@ def _app_destroy():
     gui.editor_window.window.destroy()
     os._exit(0)
     #_app.quit()
-

--- a/flowblade-trunk/Flowblade/src/dialogs/dialogs.py
+++ b/flowblade-trunk/Flowblade/src/dialogs/dialogs.py
@@ -764,6 +764,8 @@ def environment_dialog(parent_window):
         run_type = _("INSTALLATION")
     elif editorstate.app_running_from == editorstate.RUNNING_FROM_FLATPAK:
         run_type = "FLATPAK"
+    elif editorstate.app_running_from == editorstate.RUNNING_FROM_APPIMAGE:
+        run_type = "APPIMAGE"
     else:
         run_type = _("DEVELOPER VERSION")
     r4 = guiutils.get_left_justified_box([Gtk.Label(label=_("Running from: ")), Gtk.Label(label=run_type)])
@@ -2070,4 +2072,3 @@ def replace_clip_not_enough_material_info():
     primary_txt = _("Cannot replace the clip!")
     secondary_txt = _("The clip being replaced is longer then the clip being added.")
     dialogutils.warning_message(primary_txt, secondary_txt, gui.editor_window.window)
-    

--- a/flowblade-trunk/Flowblade/src/editorstate.py
+++ b/flowblade-trunk/Flowblade/src/editorstate.py
@@ -103,6 +103,7 @@ appversion = "2.24"
 RUNNING_FROM_INSTALLATION = 0
 RUNNING_FROM_DEV_VERSION = 1
 RUNNING_FROM_FLATPAK = 2
+RUNNING_FROM_APPIMAGE = 3
 app_running_from = RUNNING_FROM_INSTALLATION
 audio_monitoring_available = False
 
@@ -152,7 +153,7 @@ _trim_clips_cache = {}
 gmic_path = None
 
 # For development and test use.
-force_sdl2 = True 
+force_sdl2 = False
 
 # Saved mutestate for muted tracks whenm soloing a track. _unsolo_data == None
 # means that we are not in solo track state. 
@@ -220,19 +221,7 @@ def timeline_visible():
     return _timeline_displayed
 
 def mlt_version_is_greater_correct(test_version):
-    runtime_ver = mlt_version.split(".")
-    test_ver = test_version.split(".")
-    
-    if runtime_ver[0] > test_ver[0]:
-        return True
-    elif runtime_ver[0] == test_ver[0]:
-        if runtime_ver[1] > test_ver[1]:
-            return True
-        elif runtime_ver[1] == test_ver[1]:
-            if  runtime_ver[2] > test_ver[2]:
-                return True
-    
-    return False
+    return runtime_version_greater_then_test_version(test_version, mlt_version)
 
 def runtime_version_greater_then_test_version(test_version, runtime_version):
     runtime_ver = list(map(int, runtime_version.split(".")))

--- a/flowblade-trunk/Flowblade/src/launch/launchutils.py
+++ b/flowblade-trunk/Flowblade/src/launch/launchutils.py
@@ -10,6 +10,13 @@ def get_modules_path():
 def set_app_runtime_type(modules_path): 
     
     import editorstate
+    appdir = os.environ.get("APPDIR")
+    if appdir != None:
+        appdir = os.path.realpath(appdir)
+        if os.path.realpath(sys.argv[0]).startswith(appdir + os.sep):
+            editorstate.app_running_from = editorstate.RUNNING_FROM_APPIMAGE
+            return
+
     root_dir = modules_path.split("/")[1]
     
      # Used to decide which translations from file system are used.

--- a/flowblade-trunk/Flowblade/src/process/gmicheadless.py
+++ b/flowblade-trunk/Flowblade/src/process/gmicheadless.py
@@ -33,6 +33,7 @@ try:
 except:
     import mlt
 import os
+import shutil
 import threading
 import time
 
@@ -96,10 +97,13 @@ def main(root_path, session_id, parent_folder, script, clip_path, range_in, rang
     # Set paths.
     respaths.set_paths(root_path)
 
-    if os.path.exists("/usr/bin/gmic") == True: # distro install an dev.
-        editorstate.gmic_path = "/usr/bin/gmic"
-    elif os.path.exists("/app/bin/gmic") == True: # Flatpak
-        editorstate.gmic_path = "/app/bin/gmic"
+    gmic_path = shutil.which('gmic')
+    if gmic_path != None:
+        editorstate.gmic_path = gmic_path
+    elif os.path.exists('/usr/bin/gmic') == True: # distro install an dev.
+        editorstate.gmic_path = '/usr/bin/gmic'
+    elif os.path.exists('/app/bin/gmic') == True: # Flatpak
+        editorstate.gmic_path = '/app/bin/gmic'
     else:
         print("No G'Mic in gmicheadless main(), something is wrong.") # Should not be possible
 

--- a/flowblade-trunk/Flowblade/src/tools/gmic.py
+++ b/flowblade-trunk/Flowblade/src/tools/gmic.py
@@ -112,10 +112,13 @@ def test_availablity():
         print("G'MIC NOT found")
 
 def set_gmic_path():
-    if os.path.exists("/usr/bin/gmic") == True:
-        editorstate.gmic_path = "/usr/bin/gmic"
-    elif os.path.exists("/app/bin/gmic") == True: # File system and flatpak
-        editorstate.gmic_path = "/app/bin/gmic"
+    gmic_path = shutil.which('gmic')
+    if gmic_path != None:
+        editorstate.gmic_path = gmic_path
+    elif os.path.exists('/usr/bin/gmic') == True:
+        editorstate.gmic_path = '/usr/bin/gmic'
+    elif os.path.exists('/app/bin/gmic') == True: # File system and flatpak
+        editorstate.gmic_path = '/app/bin/gmic'
 
 def gmic_available():
     return _gmic_found
@@ -123,7 +126,7 @@ def gmic_available():
 def launch_gmic(launch_data=None):
     if _gmic_found == False:
         primary_txt = _("G'Mic not found!")
-        secondary_txt = _("G'Mic binary was not present at <b>/usr/bin/gmic</b>.\nInstall G'MIC to use this tool.")
+        secondary_txt = _("G'Mic binary was not found.\nInstall G'MIC to use this tool.")
         dialogutils.info_message(primary_txt, secondary_txt, gui.editor_window.window)
         return
 
@@ -346,9 +349,7 @@ def _finish_clip_open(use_default_profile):
     _frame_writer = gmicplayer.PreviewFrameWriter(_current_path)
 
     # Set SDL consumer version to be used.
-    #if editorstate.mlt_version_is_greater_correct("7.28.0") or editorstate.force_sdl2 == True \
-    #    or editorstate.app_running_from == editorstate.RUNNING_FROM_FLATPAK:
-    if editorstate.force_sdl2 == True:
+    if editorstate.mlt_version_is_greater_correct('7.28.0') or editorstate.force_sdl2 == True:
         gmicplayer.set_sdl_consumer_version(gmicplayer.SDL_2)
     else:
         gmicplayer.set_sdl_consumer_version(gmicplayer.SDL_1)

--- a/flowblade-trunk/Flowblade/src/tools/scripttool.py
+++ b/flowblade-trunk/Flowblade/src/tools/scripttool.py
@@ -206,9 +206,7 @@ class ScriptToolApplication(Gtk.Application):
         os.putenv('SDL_WINDOWID', str(_window.monitor.get_window().get_xid()))
 
         # Set SDL consumer version to be used.
-        #if editorstate.mlt_version_is_greater_correct("7.28.0") or editorstate.force_sdl2 == True \
-        #    or editorstate.app_running_from == editorstate.RUNNING_FROM_FLATPAK:
-        if editorstate.force_sdl2 == True:
+        if editorstate.mlt_version_is_greater_correct('7.28.0') or editorstate.force_sdl2 == True:
             gmicplayer.set_sdl_consumer_version(gmicplayer.SDL_2)
         else:
             gmicplayer.set_sdl_consumer_version(gmicplayer.SDL_1)

--- a/flowblade-trunk/Flowblade/src/translations.py
+++ b/flowblade-trunk/Flowblade/src/translations.py
@@ -50,7 +50,10 @@ def init_languages():
     if (language):
         langs += language.split(":")
 
-    if editorstate.app_running_from == editorstate.RUNNING_FROM_INSTALLATION or editorstate.app_running_from == editorstate.RUNNING_FROM_FLATPAK:
+    if editorstate.app_running_from == editorstate.RUNNING_FROM_APPIMAGE:
+        locale_path = respaths.LOCALE_PATH
+        print("Running from AppImage, using bundled translations at " + locale_path + ".")
+    elif editorstate.app_running_from == editorstate.RUNNING_FROM_INSTALLATION or editorstate.app_running_from == editorstate.RUNNING_FROM_FLATPAK:
         # Use /usr/share/locale first if available and running from installation
         # Look for installed translation in distro install
         # Were using Russian as test language

--- a/flowblade-trunk/Flowblade/src/window/editorlayout.py
+++ b/flowblade-trunk/Flowblade/src/window/editorlayout.py
@@ -195,12 +195,6 @@ def top_level_project_panel():
 def init_layout_data():
     global _panel_positions, _positions_names, _panels_names, _position_notebooks, PANEL_MINIMUM_SIZES
     _panel_positions = editorpersistance.prefs.panel_positions
-    
-    # New panel needs to be made part of saced postions on firts load of 2.26.
-    try: 
-        pos = _panel_positions[appconsts.PANEL_DISSOLVE_SELECT]
-    except:
-        _panel_positions[appconsts.PANEL_DISSOLVE_SELECT] = appconsts.PANEL_PLACEMENT_BOTTOM_ROW_RIGHT
 
     # Use default panels positions if nothing available yet or too small screen, 
     # or default panel position is empty, layout code makes too many assumptions to make that work.
@@ -212,6 +206,10 @@ def init_layout_data():
             _panel_positions[appconsts.PANEL_FILTER_SELECT] = appconsts.PANEL_PLACEMENT_NOT_VISIBLE
         editorpersistance.prefs.panel_positions = _panel_positions
         editorpersistance.save()
+
+    # New panel needs to be made part of saved positions on first load of 2.26.
+    if appconsts.PANEL_DISSOLVE_SELECT not in _panel_positions:
+        _panel_positions[appconsts.PANEL_DISSOLVE_SELECT] = appconsts.PANEL_PLACEMENT_BOTTOM_ROW_RIGHT
 
     if editorpersistance.prefs.positions_tabs == None:
         editorpersistance.prefs.positions_tabs = DEFAULT_TABS_POSITIONS
@@ -825,5 +823,4 @@ def apply_layout(layout_dict):
             
     gui.editor_window.window.show_all()
     set_positions_frames_visibility()
-
 

--- a/flowblade-trunk/flowblade
+++ b/flowblade-trunk/flowblade
@@ -29,12 +29,23 @@ print ("---------------------------")
 
 # Get launch script dir
 launch_dir = os.path.dirname(os.path.abspath(sys.argv[0]))
+real_launch_dir = os.path.realpath(launch_dir)
+appdir = os.environ.get("APPDIR")
+appdir_usr_bin = None
+if appdir != None:
+    appdir = os.path.realpath(appdir)
+    appdir_usr_bin = os.path.join(appdir, "usr", "bin")
 
 print ("Launch script dir:", launch_dir)
 
 # Update sys.path to include modules.
+# - When running in AppImage.
+if appdir_usr_bin != None and real_launch_dir == appdir_usr_bin:
+    print ("Running from AppImage...")
+    modules_path = appdir + "/usr/share/flowblade/Flowblade/src"
+    print ("modules path:", modules_path)
 # - When running on distro.
-if os.path.realpath(launch_dir) == "/usr/bin":
+elif real_launch_dir == "/usr/bin":
     print ("Running from installation...")
     modules_path = "/usr/share/flowblade/Flowblade/src"
     if not os.path.isdir(modules_path):
@@ -77,7 +88,9 @@ try:
     import app
     import editorstate
 
-    if launch_dir == "/usr/bin":
+    if appdir_usr_bin != None and real_launch_dir == appdir_usr_bin:
+        editorstate.app_running_from = editorstate.RUNNING_FROM_APPIMAGE
+    elif launch_dir == "/usr/bin":
         editorstate.app_running_from = editorstate.RUNNING_FROM_INSTALLATION
     elif launch_dir == "/app/bin": 
         editorstate.app_running_from = editorstate.RUNNING_FROM_FLATPAK

--- a/packaging/appimage/build-appimage.sh
+++ b/packaging/appimage/build-appimage.sh
@@ -1,0 +1,527 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+APP_ID="io.github.jliljebl.Flowblade"
+APP_NAME="Flowblade"
+ARCH="${ARCH:-x86_64}"
+BUILD_APPIMAGE=1
+
+usage() {
+    cat <<'USAGE'
+Usage: packaging/appimage/build-appimage.sh [--appdir-only]
+
+Build a Flowblade AppImage from an Ubuntu/Debian system with Flowblade runtime
+packages installed. Use --appdir-only to validate staging without running
+linuxdeploy.
+USAGE
+}
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --appdir-only)
+            BUILD_APPIMAGE=0
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown argument: $1" >&2
+            usage >&2
+            exit 2
+            ;;
+    esac
+    shift
+done
+
+log() {
+    printf '==> %s\n' "$*"
+}
+
+require_command() {
+    if ! command -v "$1" >/dev/null 2>&1; then
+        echo "Required command not found: $1" >&2
+        exit 1
+    fi
+}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+FLOWBLADE_DIR="$ROOT_DIR/flowblade-trunk"
+BUILD_DIR="${BUILD_DIR:-$ROOT_DIR/build/appimage}"
+APPDIR="${APPDIR:-$BUILD_DIR/${APP_NAME}.AppDir}"
+DIST_DIR="${DIST_DIR:-$ROOT_DIR/dist}"
+TOOLS_DIR="$BUILD_DIR/tools"
+DESKTOP_FILE="$APPDIR/$APP_ID.desktop"
+ICON_FILE="$APPDIR/$APP_ID.png"
+
+detect_version() {
+    python3 - "$FLOWBLADE_DIR/setup.py" <<'PY'
+import ast
+import pathlib
+import sys
+
+setup_py = pathlib.Path(sys.argv[1])
+tree = ast.parse(setup_py.read_text())
+for node in ast.walk(tree):
+    if isinstance(node, ast.Call) and getattr(node.func, "id", "") == "setup":
+        for keyword in node.keywords:
+            if keyword.arg == "version":
+                print(ast.literal_eval(keyword.value))
+                raise SystemExit(0)
+raise SystemExit("Could not find setup(version=...)")
+PY
+}
+
+VERSION="${VERSION:-$(detect_version)}"
+APPIMAGE_NAME="${APPIMAGE_NAME:-${APP_NAME}-${VERSION}-${ARCH}.AppImage}"
+
+# These package payloads contain resources that linuxdeploy cannot infer from
+# ELF dependencies alone: Python modules, GI typelibs, MLT plugins/data,
+# GDK-Pixbuf loaders, icon theme data, and external tools used by Flowblade.
+RUNTIME_PACKAGES=(
+    adwaita-icon-theme
+    ffmpeg
+    fontconfig-config
+    fonts-dejavu-core
+    frei0r-plugins
+    gmic
+    gir1.2-atk-1.0
+    gir1.2-gdkpixbuf-2.0
+    gir1.2-freedesktop
+    gir1.2-glib-2.0
+    gir1.2-harfbuzz-0.0
+    gir1.2-gtk-3.0
+    gir1.2-pango-1.0
+    hicolor-icon-theme
+    libasound2
+    libcairo-gobject2
+    libcairo2
+    libcom-err2
+    libdatrie1
+    libdrm2
+    libexpat1
+    libfontconfig1
+    libfreetype6
+    libfribidi0
+    libgbm1
+    libgdk-pixbuf-2.0-0
+    libgdk-pixbuf2.0-bin
+    libglib2.0-bin
+    libglvnd0
+    libgpg-error0
+    libgraphite2-3
+    libgtk-3-0
+    libgtk-3-bin
+    libharfbuzz0b
+    libjbig0
+    libjpeg-turbo8
+    libjack-jackd2-0
+    libmlt++7
+    libmlt-data
+    libmlt7
+    libopengl0
+    libpango-1.0-0
+    libpangocairo-1.0-0
+    libpangoft2-1.0-0
+    libpng16-16
+    librsvg2-common
+    libthai0
+    libtiff5
+    libusb-1.0-0
+    libwayland-client0
+    libwayland-cursor0
+    libwayland-egl1
+    libwebp7
+    libwebpdemux2
+    libwebpmux3
+    libxcb1
+    libxkbcommon0
+    melt
+    python3
+    python3-gi
+    python3-gi-cairo
+    python3-mlt
+    python3-numpy
+    python3-pil
+    python3-usb1
+    shared-mime-info
+    swh-plugins
+    zlib1g
+)
+
+copy_path_from_host() {
+    local src="$1"
+    local dst="$APPDIR$src"
+
+    case "$src" in
+        /|/usr|/usr/bin|/usr/lib|/usr/lib/*|/usr/share|/usr/share/doc|/usr/share/man)
+            if [ -d "$src" ] && [ ! -L "$src" ]; then
+                mkdir -p "$dst"
+                return
+            fi
+            ;;
+    esac
+
+    if [ -d "$src" ] && [ ! -L "$src" ]; then
+        mkdir -p "$dst"
+    elif [ -e "$src" ] || [ -L "$src" ]; then
+        mkdir -p "$(dirname "$dst")"
+        cp -a "$src" "$dst"
+    fi
+}
+
+copy_package_payloads() {
+    if ! command -v dpkg-query >/dev/null 2>&1; then
+        log "dpkg-query not found; skipping Debian package payload copy"
+        return
+    fi
+
+    local package path status
+    for package in "${RUNTIME_PACKAGES[@]}"; do
+        status="$(dpkg-query -W -f='${Status}' "$package" 2>/dev/null || true)"
+        if [ "$status" != "install ok installed" ]; then
+            log "Skipping package payload not installed: $package"
+            continue
+        fi
+
+        while IFS= read -r path; do
+            case "$path" in
+                ""|/|/usr/share/doc/*|/usr/share/man/*|/usr/share/lintian/*|/usr/share/bug/*)
+                    continue
+                    ;;
+            esac
+            copy_path_from_host "$path"
+        done < <(dpkg-query -L "$package")
+    done
+}
+
+remove_host_gdk_pixbuf_caches() {
+    if [ -d "$APPDIR/usr/lib" ]; then
+        find "$APPDIR/usr/lib" -path '*/gdk-pixbuf-2.0/2.10.0/loaders.cache' -type f -delete
+    fi
+}
+
+generate_appdir_mime_database() {
+    if [ ! -d "$APPDIR/usr/share/mime" ]; then
+        return
+    fi
+
+    require_command update-mime-database
+    log 'Generating AppDir MIME database'
+    XDG_DATA_DIRS="$APPDIR/usr/share:${XDG_DATA_DIRS:-/usr/local/share:/usr/share}" \
+        update-mime-database "$APPDIR/usr/share/mime"
+}
+
+copy_binary_to_appdir() {
+    local binary="$1"
+    local resolved
+    resolved="$(command -v "$binary" 2>/dev/null || true)"
+    if [ -z "$resolved" ]; then
+        return
+    fi
+
+    mkdir -p "$APPDIR/usr/bin"
+    cp -aL "$resolved" "$APPDIR/usr/bin/$binary"
+}
+
+stage_python_runtime() {
+    local python_version
+    python_version="$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')"
+    PYTHON_VERSION="$python_version"
+
+    copy_binary_to_appdir python3
+
+    if command -v "python$python_version" >/dev/null 2>&1; then
+        copy_binary_to_appdir "python$python_version"
+    fi
+
+    mkdir -p "$APPDIR/usr/lib"
+    for path in "/usr/lib/python$python_version" "/usr/lib/python3" "/usr/local/lib/python$python_version/dist-packages"; do
+        if [ -d "$path" ]; then
+            mkdir -p "$APPDIR$(dirname "$path")"
+            cp -a "$path" "$APPDIR$(dirname "$path")/"
+        fi
+    done
+}
+
+stage_flowblade() {
+    local record_file="$BUILD_DIR/install-record.txt"
+    local source_parent="$BUILD_DIR/source"
+    local source_dir="$source_parent/flowblade-trunk"
+
+    log "Staging Flowblade into AppDir"
+    mkdir -p "$BUILD_DIR" "$APPDIR" "$DIST_DIR"
+    rm -rf "$source_parent"
+    mkdir -p "$source_parent"
+    cp -a "$FLOWBLADE_DIR" "$source_parent/"
+
+    (
+        cd "$source_dir"
+        PYTHONDONTWRITEBYTECODE=1 python3 setup.py install \
+            --root="$APPDIR" \
+            --prefix=/usr \
+            --install-lib=/usr/share/flowblade \
+            --install-scripts=/usr/bin \
+            --single-version-externally-managed \
+            --record="$record_file" \
+            --no-compile
+    )
+
+    mkdir -p "$APPDIR/usr/share/flowblade/Flowblade"
+    cp -a "$source_dir/Flowblade/res" "$APPDIR/usr/share/flowblade/Flowblade/"
+    cp -a "$source_dir/Flowblade/locale" "$APPDIR/usr/share/flowblade/Flowblade/"
+    cp -a "$source_dir/Flowblade/src/launch" "$APPDIR/usr/share/flowblade/Flowblade/src/"
+
+    cp "$APPDIR/usr/share/applications/$APP_ID.desktop" "$DESKTOP_FILE"
+    cp "$APPDIR/usr/share/icons/hicolor/128x128/apps/$APP_ID.png" "$ICON_FILE"
+    sed -i 's|^Exec=.*|Exec=AppRun %f|' "$DESKTOP_FILE"
+    ln -sfn "$APP_ID.png" "$APPDIR/.DirIcon"
+}
+
+stage_appimage_helpers() {
+    mkdir -p "$APPDIR/usr/share/flowblade/appimage"
+    cp "$SCRIPT_DIR/probe-gdk-pixbuf.py" "$APPDIR/usr/share/flowblade/appimage/"
+}
+
+normalize_appimage_pngs() {
+    log 'Normalizing PNG resources'
+    python3 "$SCRIPT_DIR/normalize-pngs.py" "$APPDIR/usr/share/flowblade/Flowblade/res"
+}
+
+write_apprun() {
+    log 'Writing AppRun'
+    cat > "$APPDIR/AppRun" <<EOF
+#!/usr/bin/env bash
+set -e
+
+APPDIR="\${APPDIR:-\$(dirname "\$(readlink -f "\${BASH_SOURCE[0]}")")}"
+PYTHON_VERSION="$PYTHON_VERSION"
+
+export APPDIR
+export PATH="\$APPDIR/usr/bin:\$PATH"
+export PYTHONHOME="\$APPDIR/usr"
+export PYTHONNOUSERSITE=1
+export PYTHONPATH="\$APPDIR/usr/lib/python3/dist-packages:\$APPDIR/usr/lib/python\$PYTHON_VERSION/dist-packages:\${PYTHONPATH:-}"
+export LD_LIBRARY_PATH="\$APPDIR/usr/lib/x86_64-linux-gnu:\$APPDIR/usr/lib:\$APPDIR/lib/x86_64-linux-gnu:\$APPDIR/lib:\${LD_LIBRARY_PATH:-}"
+export GI_TYPELIB_PATH="\$APPDIR/usr/lib/x86_64-linux-gnu/girepository-1.0:\$APPDIR/usr/lib/girepository-1.0:\${GI_TYPELIB_PATH:-}"
+export GIO_EXTRA_MODULES="\$APPDIR/usr/lib/x86_64-linux-gnu/gio/modules:\${GIO_EXTRA_MODULES:-}"
+export XDG_DATA_DIRS="\$APPDIR/usr/share:\${XDG_DATA_DIRS:-/usr/local/share:/usr/share}"
+export GDK_BACKEND="\${GDK_BACKEND:-x11}"
+export SDL_VIDEODRIVER="\${SDL_VIDEODRIVER:-x11}"
+
+if [ -d "\$APPDIR/usr/share/fonts" ]; then
+    FONTCONFIG_CACHE_DIR="\${XDG_CACHE_HOME:-\${HOME:-/tmp}/.cache}/flowblade-appimage/fontconfig"
+    mkdir -p "\$FONTCONFIG_CACHE_DIR"
+    FLOWBLADE_FONTCONFIG_FILE="\$FONTCONFIG_CACHE_DIR/fonts.conf"
+    cat > "\$FLOWBLADE_FONTCONFIG_FILE" <<FONTCONFIG_EOF
+<?xml version="1.0"?>
+<!DOCTYPE fontconfig SYSTEM "urn:fontconfig:fonts.dtd">
+<fontconfig>
+  <dir>\$APPDIR/usr/share/fonts</dir>
+  <include ignore_missing="yes">\$APPDIR/etc/fonts/conf.d</include>
+  <cachedir>\$FONTCONFIG_CACHE_DIR</cachedir>
+</fontconfig>
+FONTCONFIG_EOF
+    export FONTCONFIG_FILE="\$FLOWBLADE_FONTCONFIG_FILE"
+    unset FONTCONFIG_PATH
+    unset FONTCONFIG_SYSROOT
+fi
+
+if [ -d "\$APPDIR/usr/lib/x86_64-linux-gnu/mlt-7" ]; then
+    export MLT_REPOSITORY="\$APPDIR/usr/lib/x86_64-linux-gnu/mlt-7"
+elif [ -d "\$APPDIR/usr/lib/mlt-7" ]; then
+    export MLT_REPOSITORY="\$APPDIR/usr/lib/mlt-7"
+fi
+
+if [ -d "\$APPDIR/usr/share/mlt-7" ]; then
+    export MLT_DATA="\$APPDIR/usr/share/mlt-7"
+fi
+
+if [ -d "\$APPDIR/usr/lib/x86_64-linux-gnu/frei0r-1" ]; then
+    export FREI0R_PATH="\$APPDIR/usr/lib/x86_64-linux-gnu/frei0r-1"
+elif [ -d "\$APPDIR/usr/lib/frei0r-1" ]; then
+    export FREI0R_PATH="\$APPDIR/usr/lib/frei0r-1"
+fi
+
+if [ -d "\$APPDIR/usr/lib/ladspa" ]; then
+    export LADSPA_PATH="\$APPDIR/usr/lib/ladspa"
+fi
+
+unset GDK_PIXBUF_MODULEDIR
+unset GDK_PIXBUF_MODULE_FILE
+GDK_PIXBUF_QUERY_LOADERS=''
+for candidate in \
+    "\$APPDIR/usr/bin/gdk-pixbuf-query-loaders" \
+    "\$APPDIR/usr/lib/x86_64-linux-gnu/gdk-pixbuf-2.0/gdk-pixbuf-query-loaders" \
+    "\$APPDIR/usr/lib/gdk-pixbuf-2.0/gdk-pixbuf-query-loaders"; do
+    if [ -x "\$candidate" ]; then
+        GDK_PIXBUF_QUERY_LOADERS="\$candidate"
+        break
+    fi
+done
+
+GDK_PIXBUF_LOADER_DIR=''
+for candidate in \
+    "\$APPDIR/usr/lib/x86_64-linux-gnu/gdk-pixbuf-2.0/2.10.0/loaders" \
+    "\$APPDIR/usr/lib/gdk-pixbuf-2.0/2.10.0/loaders"; do
+    if [ -d "\$candidate" ]; then
+        GDK_PIXBUF_LOADER_DIR="\$candidate"
+        break
+    fi
+done
+
+if [ -n "\$GDK_PIXBUF_QUERY_LOADERS" ] && [ -n "\$GDK_PIXBUF_LOADER_DIR" ]; then
+    CACHE_BASE="\${XDG_CACHE_HOME:-\${HOME:-/tmp}/.cache}/flowblade-appimage"
+    mkdir -p "\$CACHE_BASE"
+
+    GDK_PIXBUF_LOADERS=()
+    while IFS= read -r loader; do
+        GDK_PIXBUF_LOADERS+=("\$loader")
+    done < <(find "\$GDK_PIXBUF_LOADER_DIR" -name '*.so' -type f | LC_ALL=C sort)
+
+    if [ "\${#GDK_PIXBUF_LOADERS[@]}" -gt 0 ] && ! "\$GDK_PIXBUF_QUERY_LOADERS" "\${GDK_PIXBUF_LOADERS[@]}" > "\$CACHE_BASE/gdk-pixbuf-loaders.cache" 2>"\$CACHE_BASE/gdk-pixbuf-query-loaders.log"; then
+        cat "\$CACHE_BASE/gdk-pixbuf-query-loaders.log" >&2 || true
+    fi
+    if [ -s "\$CACHE_BASE/gdk-pixbuf-loaders.cache" ]; then
+        export GDK_PIXBUF_MODULEDIR="\$GDK_PIXBUF_LOADER_DIR"
+        export GDK_PIXBUF_MODULE_FILE="\$CACHE_BASE/gdk-pixbuf-loaders.cache"
+    fi
+fi
+
+if [ "\${FLOWBLADE_APPIMAGE_DIAGNOSTICS:-0}" = '1' ]; then
+    echo 'AppImage diagnostics:'
+    printf '  APPDIR=%s\n' "\$APPDIR"
+    printf '  GDK_PIXBUF_MODULEDIR=%s\n' "\${GDK_PIXBUF_MODULEDIR:-}"
+    printf '  GDK_PIXBUF_MODULE_FILE=%s\n' "\${GDK_PIXBUF_MODULE_FILE:-}"
+    if [ -n "\$GDK_PIXBUF_QUERY_LOADERS" ]; then
+        printf '  GDK_PIXBUF_QUERY_LOADERS=%s\n' "\$GDK_PIXBUF_QUERY_LOADERS"
+    fi
+    "\$APPDIR/usr/bin/python3" "\$APPDIR/usr/share/flowblade/appimage/probe-gdk-pixbuf.py" "\$APPDIR/usr/share/flowblade/Flowblade/res/darktheme/clip_dnd.png" || true
+fi
+
+exec "\$APPDIR/usr/bin/python3" "\$APPDIR/usr/bin/flowblade" "\$@"
+EOF
+    chmod +x "$APPDIR/AppRun"
+}
+
+validate_appdir() {
+    log "Validating AppDir metadata"
+    test -x "$APPDIR/AppRun"
+    test -x "$APPDIR/usr/bin/flowblade"
+    test -f "$DESKTOP_FILE"
+    test -f "$ICON_FILE"
+    test -d "$APPDIR/usr/share/flowblade/Flowblade/res/shortcuts"
+    test -f "$APPDIR/usr/share/flowblade/Flowblade/res/filters/filters.xml"
+    test -d "$APPDIR/usr/share/flowblade/Flowblade/locale"
+    test -f "$APPDIR/usr/share/flowblade/Flowblade/src/launch/flowbladeloaddialog"
+    test -f "$APPDIR/usr/share/flowblade/Flowblade/src/launch/flowbladeaudiorender"
+
+    if command -v desktop-file-validate >/dev/null 2>&1; then
+        desktop-file-validate "$DESKTOP_FILE"
+    fi
+}
+
+download_linuxdeploy() {
+    require_command curl
+    mkdir -p "$TOOLS_DIR"
+
+    LINUXDEPLOY="${LINUXDEPLOY:-$TOOLS_DIR/linuxdeploy-$ARCH.AppImage}"
+    if [ ! -x "$LINUXDEPLOY" ]; then
+        log "Downloading linuxdeploy"
+        curl -L \
+            "https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-$ARCH.AppImage" \
+            -o "$LINUXDEPLOY"
+        chmod +x "$LINUXDEPLOY"
+    fi
+}
+
+run_linuxdeploy() {
+    local args=(
+        --appdir "$APPDIR"
+        --desktop-file "$DESKTOP_FILE"
+        --icon-file "$ICON_FILE"
+        --executable "$APPDIR/usr/bin/python3"
+    )
+
+    for binary in ffmpeg ffprobe gmic melt melt-7; do
+        if [ -x "$APPDIR/usr/bin/$binary" ]; then
+            args+=(--executable "$APPDIR/usr/bin/$binary")
+        fi
+    done
+
+    local find_roots=()
+    for dir in "$APPDIR/usr/lib" "$APPDIR/lib"; do
+        if [ -d "$dir" ]; then
+            find_roots+=("$dir")
+        fi
+    done
+
+    if [ "${#find_roots[@]}" -gt 0 ]; then
+        while IFS= read -r -d '' library; do
+            args+=(--library "$library")
+        done < <(find "${find_roots[@]}" -type f \( -name '*.so' -o -name '*.so.*' \) -print0)
+    fi
+
+    mkdir -p "$DIST_DIR"
+    export APPIMAGE_EXTRACT_AND_RUN=1
+    export ARCH
+    export LDAI_OUTPUT="$DIST_DIR/$APPIMAGE_NAME"
+
+    log "Building $LDAI_OUTPUT"
+    (
+        cd "$BUILD_DIR"
+        "$LINUXDEPLOY" "${args[@]}" --output appimage
+    )
+
+    if [ ! -f "$LDAI_OUTPUT" ]; then
+        local produced=""
+        while IFS= read -r candidate; do
+            produced="$candidate"
+            break
+        done < <(find "$BUILD_DIR" "$ROOT_DIR" -maxdepth 1 -type f -name '*.AppImage')
+
+        if [ -z "$produced" ]; then
+            echo "linuxdeploy finished but no AppImage was found" >&2
+            exit 1
+        fi
+        mv "$produced" "$LDAI_OUTPUT"
+    fi
+
+    chmod +x "$LDAI_OUTPUT"
+    log "Created $LDAI_OUTPUT"
+}
+
+main() {
+    require_command python3
+
+    log "Preparing $APPDIR"
+    rm -rf "$APPDIR"
+    mkdir -p "$BUILD_DIR" "$DIST_DIR"
+
+    stage_flowblade
+    copy_package_payloads
+    remove_host_gdk_pixbuf_caches
+    generate_appdir_mime_database
+    stage_python_runtime
+    copy_binary_to_appdir ffmpeg
+    copy_binary_to_appdir ffprobe
+    copy_binary_to_appdir gmic
+    copy_binary_to_appdir melt
+    copy_binary_to_appdir melt-7
+    stage_appimage_helpers
+    normalize_appimage_pngs
+    write_apprun
+    validate_appdir
+
+    if [ "$BUILD_APPIMAGE" -eq 0 ]; then
+        log "AppDir staged at $APPDIR"
+        exit 0
+    fi
+
+    download_linuxdeploy
+    run_linuxdeploy
+}
+
+main "$@"

--- a/packaging/appimage/normalize-pngs.py
+++ b/packaging/appimage/normalize-pngs.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+
+import sys
+from pathlib import Path
+
+from PIL import Image
+
+
+def normalize_pngs(root: Path) -> int:
+    '''
+    Convert indexed, grayscale, and other non-RGB PNG resources to RGBA.
+
+    The AppImage bundles its own GTK/GdkPixbuf loader stack, and some host
+    distributions are less forgiving when loading Flowblade's theme/icon PNGs
+    through that stack. Saving resources in a plain RGBA format keeps startup
+    smoke tests and runtime icon loading consistent across distributions.
+    '''
+    converted = 0
+    for png_file in sorted(root.rglob('*.png')):
+        with Image.open(png_file) as image:
+            if image.mode in {'RGB', 'RGBA'}:
+                continue
+
+            image.convert('RGBA').save(png_file)
+            converted += 1
+
+    return converted
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print('Usage: normalize-pngs.py PNG_ROOT', file=sys.stderr)
+        return 2
+
+    root = Path(sys.argv[1])
+    converted = normalize_pngs(root)
+    print(f'Normalized {converted} PNG files under {root}')
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/packaging/appimage/probe-gdk-pixbuf.py
+++ b/packaging/appimage/probe-gdk-pixbuf.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+
+import sys
+from pathlib import Path
+
+import gi
+
+gi.require_version('GdkPixbuf', '2.0')
+from gi.repository import GdkPixbuf
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print('Usage: probe-gdk-pixbuf.py PNG_FILE', file=sys.stderr)
+        return 2
+
+    png_file = Path(sys.argv[1])
+    header = png_file.read_bytes()[:16].hex()
+    print(f'  PNG file: {png_file} size={png_file.stat().st_size} header={header}')
+
+    formats = GdkPixbuf.Pixbuf.get_formats()
+    png_format = next((fmt for fmt in formats if fmt.get_name() == 'png'), None)
+    if png_format is not None:
+        print(
+            '  GdkPixbuf png format: '
+            f'disabled={png_format.is_disabled()} '
+            f'extensions={",".join(png_format.get_extensions())} '
+            f'mimes={",".join(png_format.get_mime_types())}'
+        )
+
+    format_names = ','.join(fmt.get_name() for fmt in formats)
+    print(f'  GdkPixbuf formats: {format_names}')
+
+    GdkPixbuf.Pixbuf.new_from_file(str(png_file))
+    print('  GdkPixbuf PNG probe: ok')
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/packaging/appimage/smoke-test-appimage-containers.sh
+++ b/packaging/appimage/smoke-test-appimage-containers.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+APPIMAGE="${1:-}"
+IMAGES="${APPIMAGE_SMOKE_CONTAINER_IMAGES:-ubuntu:22.04 ubuntu:24.04 debian:12 debian:13 fedora:latest archlinux:latest opensuse/tumbleweed:latest}"
+OPTIONAL_IMAGES="${APPIMAGE_SMOKE_OPTIONAL_CONTAINER_IMAGES:-}"
+CONTAINER_SMOKE_DIR="$ROOT_DIR/build/appimage-smoke-containers"
+
+if [ -z "$APPIMAGE" ]; then
+    while IFS= read -r candidate; do
+        APPIMAGE="$candidate"
+        break
+    done < <(find "$ROOT_DIR/dist" -maxdepth 1 -type f -name '*.AppImage' -print | sort)
+fi
+
+if [ -z "$APPIMAGE" ] || [ ! -f "$APPIMAGE" ]; then
+    echo "No AppImage found to smoke test in containers" >&2
+    exit 1
+fi
+
+if ! command -v docker >/dev/null 2>&1; then
+    echo "Required command not found: docker" >&2
+    exit 1
+fi
+
+container_install_command() {
+    local image="$1"
+
+    case "$image" in
+        debian:*|ubuntu:*)
+            printf '%s\n' \
+                'export DEBIAN_FRONTEND=noninteractive' \
+                'apt-get update' \
+                'apt-get install -y --no-install-recommends bash ca-certificates coreutils findutils grep xauth xvfb' \
+                'rm -rf /var/lib/apt/lists/*'
+            ;;
+        fedora:*)
+            printf '%s\n' \
+                'dnf -y --setopt=install_weak_deps=False install bash ca-certificates coreutils findutils grep xorg-x11-server-Xvfb xorg-x11-xauth' \
+                'dnf clean all'
+            ;;
+        archlinux:*)
+            printf '%s\n' \
+                'pacman -Sy --noconfirm --needed bash ca-certificates coreutils findutils grep xorg-server-xvfb xorg-xauth' \
+                'pacman -Scc --noconfirm'
+            ;;
+        opensuse/*)
+            printf '%s\n' \
+                'zypper --non-interactive --gpg-auto-import-keys refresh' \
+                'zypper --non-interactive --gpg-auto-import-keys install --no-recommends bash ca-certificates coreutils findutils grep xauth xorg-x11-server-Xvfb' \
+                'zypper clean --all'
+            ;;
+        gentoo/*)
+            printf '%s\n' \
+                'if [ ! -e /var/db/repos/gentoo/profiles/repo_name ]; then emerge-webrsync --quiet; fi' \
+                'FEATURES="${FEATURES:-} getbinpkg -news" emerge --getbinpkgonly --usepkg --binpkg-respect-use=y --jobs=1 --quiet app-shells/bash app-misc/ca-certificates sys-apps/coreutils sys-apps/findutils sys-apps/grep x11-apps/xauth'
+            ;;
+        *)
+            echo "Unsupported AppImage smoke container image: $image" >&2
+            return 1
+            ;;
+    esac
+}
+
+appimage_rel="${APPIMAGE#$ROOT_DIR/}"
+mkdir -p "$CONTAINER_SMOKE_DIR"
+
+failed_images=()
+optional_failed_images=()
+
+run_container_smoke() {
+    local image="$1"
+    local optional="${2:-0}"
+    local safe_image_name
+    local smoke_dir
+    local install_command
+
+    safe_image_name="${image//\//-}"
+    safe_image_name="${safe_image_name//:/-}"
+    smoke_dir="/work/build/appimage-smoke-containers/$safe_image_name"
+    install_command="$(container_install_command "$image")"
+
+    printf '==> Smoke testing AppImage in %s\n' "$image"
+    if ! docker run --rm \
+        --volume "$ROOT_DIR:/work" \
+        --workdir /work \
+        --env APPIMAGE_SMOKE_MANUAL_EXTRACT=1 \
+        --env APPIMAGE_SMOKE_TIMEOUT="${APPIMAGE_SMOKE_TIMEOUT:-30s}" \
+        --env FLOWBLADE_APPIMAGE_DIAGNOSTICS="${FLOWBLADE_APPIMAGE_DIAGNOSTICS:-1}" \
+        --env SMOKE_DIR="$smoke_dir" \
+        "$image" \
+        bash -lc "$install_command"$'\n'"trap 'chmod -R a+rwX /work/build/appimage-smoke-containers || true' EXIT"$'\n'"packaging/appimage/smoke-test-appimage.sh '$appimage_rel'"; then
+        if [ "$optional" = '1' ]; then
+            optional_failed_images+=("$image")
+        else
+            failed_images+=("$image")
+        fi
+    fi
+}
+
+read -r -a images <<< "$IMAGES"
+for image in "${images[@]}"; do
+    run_container_smoke "$image"
+done
+
+read -r -a optional_images <<< "$OPTIONAL_IMAGES"
+for image in "${optional_images[@]}"; do
+    if [ -n "$image" ]; then
+        run_container_smoke "$image" 1
+    fi
+done
+
+if [ "${#optional_failed_images[@]}" -gt 0 ]; then
+    printf 'Optional AppImage container smoke test failed in:'
+    printf ' %s' "${optional_failed_images[@]}"
+    printf '\n'
+fi
+
+if [ "${#failed_images[@]}" -gt 0 ]; then
+    printf 'AppImage container smoke test failed in:'
+    printf ' %s' "${failed_images[@]}"
+    printf '\n' >&2
+    exit 1
+fi
+
+echo '==> AppImage container smoke tests passed'

--- a/packaging/appimage/smoke-test-appimage.sh
+++ b/packaging/appimage/smoke-test-appimage.sh
@@ -1,0 +1,285 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+APPIMAGE="${1:-}"
+APPDIR="${APPDIR:-$ROOT_DIR/build/appimage/Flowblade.AppDir}"
+SMOKE_DIR="${SMOKE_DIR:-$ROOT_DIR/build/appimage-smoke}"
+SMOKE_TIMEOUT="${APPIMAGE_SMOKE_TIMEOUT:-30s}"
+LOG_FILE="$SMOKE_DIR/flowblade-appimage-smoke.log"
+
+if [ -z "$APPIMAGE" ]; then
+    while IFS= read -r candidate; do
+        APPIMAGE="$candidate"
+        break
+    done < <(find "$ROOT_DIR/dist" -maxdepth 1 -type f -name '*.AppImage' -print | sort)
+fi
+
+if [ -z "$APPIMAGE" ] || [ ! -f "$APPIMAGE" ]; then
+    echo "No AppImage found to smoke test" >&2
+    exit 1
+fi
+
+APPIMAGE="$(readlink -f "$APPIMAGE")"
+
+if ! command -v xvfb-run >/dev/null 2>&1 && ! command -v Xvfb >/dev/null 2>&1; then
+    echo "Required command not found: xvfb-run or Xvfb" >&2
+    exit 1
+fi
+
+run_with_xvfb() {
+    local display
+    local xvfb_pid
+    local xvfb_log
+    local ready=0
+
+    display=":$((100 + (RANDOM % 900)))"
+    xvfb_log="$SMOKE_DIR/xvfb.log"
+
+    Xvfb "$display" -screen 0 1920x1080x24 >"$xvfb_log" 2>&1 &
+    xvfb_pid=$!
+
+    for _ in {1..50}; do
+        if [ -S "/tmp/.X11-unix/X${display#:}" ]; then
+            ready=1
+            break
+        fi
+
+        if ! kill -0 "$xvfb_pid" 2>/dev/null; then
+            cat "$xvfb_log" >&2
+            echo "Xvfb exited before the smoke test could start" >&2
+            return 1
+        fi
+
+        sleep 0.1
+    done
+
+    if [ "$ready" -ne 1 ]; then
+        cat "$xvfb_log" >&2
+        echo "Xvfb did not create display socket $display" >&2
+        kill "$xvfb_pid" 2>/dev/null || true
+        wait "$xvfb_pid" 2>/dev/null || true
+        return 1
+    fi
+
+    DISPLAY="$display" "$@"
+    local status=$?
+
+    kill "$xvfb_pid" 2>/dev/null || true
+    wait "$xvfb_pid" 2>/dev/null || true
+
+    return "$status"
+}
+
+validate_appdir_payload() {
+    if [ ! -d "$APPDIR" ]; then
+        echo "==> AppDir not found at $APPDIR, skipping AppDir payload validation"
+        return
+    fi
+
+    local missing=0
+    local lib_roots=()
+    local library
+    local typelib
+    local root
+    local required_libraries=(
+        libasound.so.2
+        libcairo-gobject.so.2
+        libcairo.so.2
+        libcom_err.so.2
+        libdatrie.so.1
+        libdrm.so.2
+        libexpat.so.1
+        libfontconfig.so.1
+        libfreetype.so.6
+        libfribidi.so.0
+        libgbm.so.1
+        libGLdispatch.so.0
+        libgpg-error.so.0
+        libgraphite2.so.3
+        libharfbuzz.so.0
+        libjbig.so.0
+        libjack.so.0
+        libjpeg.so.8
+        libOpenGL.so.0
+        libpango-1.0.so.0
+        libpangocairo-1.0.so.0
+        libpangoft2-1.0.so.0
+        libpng16.so.16
+        libthai.so.0
+        libtiff.so.5
+        libusb-1.0.so.0
+        libwayland-client.so.0
+        libwayland-cursor.so.0
+        libwayland-egl.so.1
+        libwebp.so.7
+        libwebpdemux.so.2
+        libwebpmux.so.3
+        libxcb.so.1
+        libxkbcommon.so.0
+        libz.so.1
+    )
+    local required_typelibs=(
+        Atk-1.0
+        Gdk-3.0
+        GdkPixbuf-2.0
+        GdkX11-3.0
+        GIRepository-2.0
+        Gio-2.0
+        GLib-2.0
+        GModule-2.0
+        GObject-2.0
+        Gtk-3.0
+        HarfBuzz-0.0
+        Pango-1.0
+        PangoCairo-1.0
+        cairo-1.0
+        fontconfig-2.0
+        freetype2-2.0
+        xlib-2.0
+    )
+
+    echo "==> Validating bundled GI typelibs in $APPDIR"
+    for typelib in "${required_typelibs[@]}"; do
+        if [ -z "$(find "$APPDIR/usr/lib" -path "*/girepository-1.0/$typelib.typelib" -type f -print -quit 2>/dev/null)" ]; then
+            echo "Missing bundled GI typelib: $typelib.typelib" >&2
+            missing=1
+        fi
+    done
+
+    echo "==> Validating bundled MIME database in $APPDIR"
+    for path in "$APPDIR/usr/share/mime/mime.cache" "$APPDIR/usr/share/mime/magic"; do
+        if [ ! -f "$path" ]; then
+            echo "Missing bundled MIME database file: ${path#$APPDIR/}" >&2
+            missing=1
+        fi
+    done
+
+    echo "==> Validating bundled Fontconfig data in $APPDIR"
+    if [ ! -f "$APPDIR/etc/fonts/fonts.conf" ]; then
+        echo 'Missing bundled Fontconfig configuration: etc/fonts/fonts.conf' >&2
+        missing=1
+    fi
+    if [ -z "$(find "$APPDIR/usr/share/fonts" -type f \( -name '*.ttf' -o -name '*.otf' \) -print -quit 2>/dev/null)" ]; then
+        echo 'Missing bundled font files under usr/share/fonts' >&2
+        missing=1
+    fi
+
+    for root in "$APPDIR/usr/lib" "$APPDIR/lib"; do
+        if [ -d "$root" ]; then
+            lib_roots+=("$root")
+        fi
+    done
+
+    echo "==> Validating bundled shared libraries in $APPDIR"
+    for library in "${required_libraries[@]}"; do
+        if [ "${#lib_roots[@]}" -eq 0 ] || [ -z "$(find "${lib_roots[@]}" -name "$library" -print -quit 2>/dev/null)" ]; then
+            echo "Missing bundled shared library: $library" >&2
+            missing=1
+        fi
+    done
+
+    if [ "$missing" -ne 0 ]; then
+        exit 1
+    fi
+}
+
+validate_appdir_payload
+
+mkdir -p "$SMOKE_DIR/home" "$SMOKE_DIR/runtime" "$SMOKE_DIR/config" "$SMOKE_DIR/data" "$SMOKE_DIR/cache"
+chmod 700 "$SMOKE_DIR/runtime"
+chmod +x "$APPIMAGE"
+
+RUN_TARGET="$APPIMAGE"
+if [ "${APPIMAGE_SMOKE_MANUAL_EXTRACT:-0}" = '1' ]; then
+    EXTRACT_DIR="$SMOKE_DIR/appimage-extract"
+    rm -rf "$EXTRACT_DIR"
+    mkdir -p "$EXTRACT_DIR"
+    (
+        cd "$EXTRACT_DIR"
+        "$APPIMAGE" --appimage-extract >/dev/null
+    )
+    RUN_TARGET="$EXTRACT_DIR/squashfs-root/AppRun"
+    if [ ! -x "$RUN_TARGET" ]; then
+        printf 'Extracted AppRun is not executable: %s\n' "$RUN_TARGET" >&2
+        exit 1
+    fi
+fi
+
+printf '==> Smoke testing %s\n' "$RUN_TARGET"
+app_command=(
+    env
+        HOME="$SMOKE_DIR/home"
+        XDG_CONFIG_HOME="$SMOKE_DIR/config"
+        XDG_DATA_HOME="$SMOKE_DIR/data"
+        XDG_CACHE_HOME="$SMOKE_DIR/cache"
+        XDG_RUNTIME_DIR="$SMOKE_DIR/runtime"
+        PYTHONUNBUFFERED=1
+        NO_AT_BRIDGE=1
+        SDL_AUDIODRIVER="${SDL_AUDIODRIVER:-dummy}"
+        "$RUN_TARGET"
+)
+
+set +e
+if command -v xvfb-run >/dev/null 2>&1; then
+    timeout --kill-after=5s "$SMOKE_TIMEOUT" \
+        xvfb-run -a -s "-screen 0 1920x1080x24" \
+        "${app_command[@]}" >"$LOG_FILE" 2>&1
+else
+    run_with_xvfb \
+        timeout --kill-after=5s "$SMOKE_TIMEOUT" \
+        "${app_command[@]}" >"$LOG_FILE" 2>&1
+fi
+status=$?
+set -e
+
+cat "$LOG_FILE"
+
+case "$status" in
+    0)
+        echo "==> AppImage exited cleanly during smoke test"
+        ;;
+    124|137)
+        # GNU timeout can return 137 when --kill-after escalates to SIGKILL.
+        echo "==> AppImage remained running for $SMOKE_TIMEOUT"
+        ;;
+    *)
+        echo "AppImage exited with status $status during smoke test" >&2
+        exit "$status"
+        ;;
+esac
+
+required_markers=(
+    "Running from AppImage..."
+    "MLT found, version:"
+    "Application version:"
+    "GTK+ version:"
+    "Create SDL1 consumer..."
+)
+
+for marker in "${required_markers[@]}"; do
+    if ! grep -Fq "$marker" "$LOG_FILE"; then
+        echo "Smoke test log is missing expected marker: $marker" >&2
+        exit 1
+    fi
+done
+
+fatal_markers=(
+    "MLT not found, exiting"
+    "Failed to import module app.py"
+    "Traceback (most recent call last)"
+    "Fatal Python error"
+    "Segmentation fault"
+    "error while loading shared libraries"
+    "cannot open shared object file"
+)
+
+for marker in "${fatal_markers[@]}"; do
+    if grep -Fq "$marker" "$LOG_FILE"; then
+        echo "Smoke test log contains fatal marker: $marker" >&2
+        exit 1
+    fi
+done
+
+echo "==> AppImage smoke test passed"


### PR DESCRIPTION
## Summary

Adds automated AppImage packaging for Flowblade releases, with a reusable local build script and CI validation path.

The workflow builds an x86_64 AppImage on release events, uploads it as a workflow artifact, and attaches it to the GitHub release when the event is an actual release. It can also be run on the validation branch used for this PR.

Prepared with Codex (GPT-5, xhigh reasoning).

## Runtime Packaging

- Bundles Flowblade runtime dependencies, Python GI typelibs, GTK/GDK resources, MLT plugins/data, fonts, translations, pixbuf loaders, and supporting shared libraries.
- Configures the AppImage launcher for X11 GTK/SDL backends by default, which avoids missing Wayland library failures on non-Wayland hosts.
- Sets AppImage-local fontconfig and GDK pixbuf paths.
- Includes fixes for missing runtime pieces found during manual and CI smoke testing, including typelibs such as xlib/HarfBuzz and libraries such as libwayland-client and libcom_err.

## Smoke Tests

- Adds a direct AppImage startup smoke test.
- Adds container smoke coverage for Ubuntu 22.04, Ubuntu 24.04, Debian 12, Debian 13, Fedora, Arch Linux, and openSUSE Tumbleweed.
- Leaves Gentoo as an optional smoke image because the currently tested Gentoo binary package path did not provide the required Xvfb package reliably enough for default CI.
- Uses dummy SDL audio during CI smoke tests so headless runners without an audio device do not fail after Flowblade reaches playback initialization.

## Flowblade Runtime Fix

Fixes the MLT SDL consumer selection for the bundled Ubuntu 22.04 MLT 7.4 runtime. The previous version comparison used string ordering, so 7.4.0 was treated as newer than 7.28.0 and Flowblade selected the SDL2 path. That caused the separate black `MLT` window during AppImage playback tests.

This PR restores the SDL1 path for MLT versions older than 7.28.0 and keeps the SDL2 path available for newer MLT versions or explicit force mode.

## Validation

- `bash -n packaging/appimage/build-appimage.sh packaging/appimage/smoke-test-appimage.sh packaging/appimage/smoke-test-appimage-containers.sh`
- `python3 -m py_compile flowblade-trunk/Flowblade/src/app.py flowblade-trunk/Flowblade/src/editorstate.py flowblade-trunk/Flowblade/src/tools/scripttool.py flowblade-trunk/Flowblade/src/tools/gmic.py`
- Local rebuilt AppImage smoke passed with SDL1 consumer startup.
- Manual Gentoo/X11 AppImage run confirmed by tester after the SDL consumer fix.
- Fork CI passed on the squashed commit: https://github.com/vitaly-zdanevich/flowblade/actions/runs/27852951649



