### PR TITLE
[codex] Make USB HID dependency optional

### DIFF
--- a/flowblade-trunk/Flowblade/src/usb/usbhid.py
+++ b/flowblade-trunk/Flowblade/src/usb/usbhid.py
@@ -32,7 +32,12 @@ drivers in the usbhiddrivers module.
 
 from gi.repository import GObject
 
-import usb1
+try:
+    import usb1
+except ImportError as e:
+    # USB jog/shuttle support is optional, so keep application startup working.
+    usb1 = None
+    _usb1_import_error = e
 
 import time
 
@@ -86,6 +91,10 @@ def start_usb_hid_input(device_config_name):
 
     global usb_driver_ctx
     global usb_hid_input_id
+
+    if usb1 is None:
+        raise UsbHidError("USB HID support requires python-libusb1: %s" % \
+                          (str(_usb1_import_error),))
 
     if usb_driver_ctx is not None:
         raise UsbHidError("USB HID device already in use")


### PR DESCRIPTION
## What changed

This makes the `usb1` import in `Flowblade/src/usb/usbhid.py` optional. Flowblade can still import the USB HID module and enumerate configured jog/shuttle device configs when `python-libusb1` is not installed.

## Why

USB jog/shuttle support is optional, but importing `usb1` at module load time makes application startup fail on systems that do not package or install `python-libusb1` by default.

When USB HID input is actually started without `usb1`, the code now raises a clear `UsbHidError` explaining that `python-libusb1` is required.

## Validation

- `python -m py_compile flowblade-trunk/Flowblade/src/usb/usbhid.py`
- Local import simulation with `usb1` blocked confirmed that config metadata access still works and `start_usb_hid_input()` raises `UsbHidError`.