### PR TITLE
Set SDL_VIDEODRIVER on launch

### DIFF
--- a/flowblade-trunk/installdata/io.github.jliljebl.Flowblade.desktop
+++ b/flowblade-trunk/installdata/io.github.jliljebl.Flowblade.desktop
@@ -3,7 +3,7 @@ Name=Flowblade Movie Editor
 GenericName=Movie Editor
 X-GNOME-FullName=Flowblade Movie Editor
 Comment=Edit media to create movies
-Exec=env GDK_BACKEND=x11 flowblade %f
+Exec=env GDK_BACKEND=x11 SDL_VIDEODRIVER=x11 flowblade %f
 Terminal=false
 Type=Application
 Icon=io.github.jliljebl.Flowblade


### PR DESCRIPTION
Without this, Flowblade fails to launch on XWayland if the user sets the `SDL_VIDEODRIVER` globally to `wayland`.