### PR TITLE
Add StartupWMClass to desktop entry

### DIFF
--- a/flowblade-trunk/installdata/io.github.jliljebl.Flowblade.desktop
+++ b/flowblade-trunk/installdata/io.github.jliljebl.Flowblade.desktop
@@ -9,5 +9,6 @@ Type=Application
 Icon=io.github.jliljebl.Flowblade
 Categories=GNOME;GTK;AudioVideo;AudioVideoEditing;
 MimeType=application/vnd.flowblade-project;
+StartupWMClass=Flowblade
 X-Ubuntu-Gettext-Domain=Flowblade
 Name[en_US]=flowblade


### PR DESCRIPTION
This is needed for desktop environments like GNOME to be able to associate the window with the desktop file and show the appropriate icon on the dock.